### PR TITLE
Adding CONTRIBUTING document and related infrastructure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+      language: python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change log
+
+## JAX-GalSim 0.0.1 (Unreleased)
+
+
+* Changes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,131 @@
+# JAX-GalSim Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at francois.lanusse@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Once you have some code you wish to contribute, you can follow this procedure to
 
   ```bash
   git clone --recurse-submodules https://github.com/YOUR_USERNAME/JAX-GalSim
-  cd JAX-GalSIM
+  cd JAX-GalSim
   pip install --user -e .
   ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Everyone is welcome to contribute to this project, and contributions can take many different forms, from helping to answer questions on the [discussions page](https://github.com/GalSim-developers/JAX-GalSim/discussions), to contributing to the code-base by making a Pull Request.
 
-In order to foster an open, inclusive, and welcoming community, all contributors agree to adhere to [the Astropy code of conduct](https://www.astropy.org/code_of_conduct.html), which we adopt in this project.
+In order to foster an open, inclusive, and welcoming community, all contributors agree to adhere to [JAX-GalSim code of conduct](CODE_OF_CONDUCT.md).
 
 ## Contributing code using Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,140 @@
+# Contributing to JAX-GalSim
+
+Everyone is welcome to contribute to this project, and contributions can take many different forms, from helping to answer questions on the [discussions page](https://github.com/GalSim-developers/JAX-GalSim/discussions), to contributing to the code-base by making a Pull Request.
+
+In order to foster an open, inclusive, and welcoming community, all contributors agree to adhere to [the Astropy code of conduct](https://www.astropy.org/code_of_conduct.html), which we adopt in this project.
+
+
+## Contributing code using Pull Requests
+
+Code contributions are most welcome. You can in particular look for GitHub issues marked as `contributions welcome` or `good first issue`. But you can also propose adding a new functionality, in which case you may find it beneficial to first open a GitHub issue to discuss the feature you want to implement ahead of opening a Pull Request.
+
+
+Once you have some code you wish to contribute, you can follow this procedure to prepare a Pull Request:
+
+- Fork the JAX-GalSim repository under your own account, using the **Fork** button on the top right of the [GitHub page](https://github.com/GalSim-developers/JAX-GalSim).
+
+- Clone and pip install your fork of the repository like so:
+  ```bash
+  git clone https://github.com/YOUR_USERNAME/JAX-GalSim
+  cd JAX-GalSIM
+  pip install --user -e .
+  ```
+  This will install your local fork in editable mode, meaning you can directly modify source files in this folder without having to reinstall the package for them to be taken into account.
+
+- Open a branch for your developments:
+  ```bash
+  git checkout -b name-that-describes-my-feature
+  ```
+
+- Add your changes to the code using your favorite editor. You may at any moment test that everything is still working by running the test suite. From the root folder of the repository, run:
+  ```bash
+  pytest
+  ```
+
+- Once you are happy with your modifications, commit them, and push your changes to GitHub:
+  ```python
+  git add file_I_changed.py
+  git commit -m "a message that describes your modifications"
+  git push -set-upstream origin name-that-describes-my-feature
+  ```
+
+- From your GitHub interface, you should now be able to open a Pull Request to the JAX-GalSim repository. 
+
+Before submitting your PR, have a look at the procedure documented below.
+
+### Checklist before opening a Pull Request
+
+- Pull Requests should be self-contained and limited in scope, otherwise they become too difficult to review. If your modifications are broad, consider opening several smaller Pull Requests.
+
+- Make sure your fork and branch are up-to-date with the `main` branch of JAX-GalSim. To update your local branch, you may do so from the GitHub interface, or you may use this CLI command:
+  ```bash
+  # Only needs to be done once:
+  git remote add upstream http://www.github.com/GalSim-developers/JAX-GalSim
+  # This will update your local branch
+  git fetch upstream
+  git rebase upstream/main
+  ```
+
+- Make sure the unit tests still work:
+  ```bash
+  pytest
+  ```
+  Ideally there should be some new unit tests for the new functionality, unless the work is completely covered by existing unit tests.
+
+- Make sure your code conforms to the [Black](https://github.com/psf/black) style:
+  ```bash
+  black .
+  ```
+  If you haven't installed it already, you can install Black with `pip install black`.
+
+- Update CHANGELOG.md to mention your change.
+
+- Make sure any new files have BSD license at the top.
+
+- If your changes contain multiple commits, we encourage you to squash them into a single (or very few) commit, before opening the PR. To do so, you can using this command:
+```bash
+git rebase -i
+```
+
+### Opening the Pull Request
+
+- On the GitHub site, go to "Code". Then click the green "Compare and Review" button. Your branch is probably in the "Example Comparisons" list, so click on it. If not, select it for the "compare" branch.
+
+- Make sure you are comparing your new branch to the upstream `main`. Press Create Pull Request button.
+
+- Give a brief title. (We usually leave the branch number as the start of the title.)
+
+- Explain the major changes you are asking to be code reviewed. Often it is useful to open a second tab in your browser where you can look through the diff yourself to remind yourself of all the changes you have made.
+
+### After submitting the pull request
+
+- Check to make sure that the PR can be merged cleanly. If it can, GitHub will report that "This branch has no conflicts with the base branch." If it doesn't, then you need to merge from master into your branch and resolve any conflicts.
+
+- Wait a few minutes for the continuous integration tests to be run. Then make sure that the tests reports no errors. If not, click through to the details and try to figure out what is causing the error and fix it.
+
+### After code review
+
+- Once at least 1 and preferably 2 people have reviewed the code, and you have responded to all of their comments, we generally solicit for "any other comments" and give people a few more days before merging.
+
+- Click the "Merge pull request" button at the bottom of the PR page.
+
+- Click the "Delete branch" button.
+
+## Guidelines for Code Style and Documentation
+
+### Code Style
+
+In this project we follow the [Black](https://github.com/psf/black) code formatting guidelines` (Any color you like...) This means that all code should be automatically formatted using Black and CI will fail if that's not the case. 
+
+You can install Black locally like so:
+```bash
+pip install black 
+```
+And run it manually from the root directory of your local clone with `black .`
+
+We highly recommend installing `pre-commit`, which will take care of running Black for you before any commit you make:
+```bash
+pip install pre-commit
+```
+And that's all you need to do from now on.
+
+
+### Documentation style
+
+JAX-GalSim follows the NumPy/SciPy format: https://numpydoc.readthedocs.io/en/latest/format.html
+
+However, most JAX-GalSim function will directly inherit the documentation from the reference GalSim project. We recommend avoid copy/pasting documentation, and instead using the `_wraps` utility to automatically reuse GalSim documentation:
+
+```python
+import galsim as _galsim
+from jax._src.numpy.util import _wraps
+from jax.tree_util import register_pytree_node_class
+
+@_wraps(_galsim.Add, 
+        lax_description="Does not support `ChromaticObject` at this point.")
+def Add(*args, **kwargs):
+    return Sum(*args, **kwargs)
+```
+
+Note that this tool has the option of providing a `lax_description` which will be added to the reference documentation, and which can be use to document any differences with GalSim, typically a restricted set of features being available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,42 +4,45 @@ Everyone is welcome to contribute to this project, and contributions can take ma
 
 In order to foster an open, inclusive, and welcoming community, all contributors agree to adhere to [the Astropy code of conduct](https://www.astropy.org/code_of_conduct.html), which we adopt in this project.
 
-
 ## Contributing code using Pull Requests
 
 Code contributions are most welcome. You can in particular look for GitHub issues marked as `contributions welcome` or `good first issue`. But you can also propose adding a new functionality, in which case you may find it beneficial to first open a GitHub issue to discuss the feature you want to implement ahead of opening a Pull Request.
-
 
 Once you have some code you wish to contribute, you can follow this procedure to prepare a Pull Request:
 
 - Fork the JAX-GalSim repository under your own account, using the **Fork** button on the top right of the [GitHub page](https://github.com/GalSim-developers/JAX-GalSim).
 
 - Clone and pip install your fork of the repository like so:
+
   ```bash
-  git clone https://github.com/YOUR_USERNAME/JAX-GalSim
+  git clone --recurse-submodules https://github.com/YOUR_USERNAME/JAX-GalSim
   cd JAX-GalSIM
   pip install --user -e .
   ```
-  This will install your local fork in editable mode, meaning you can directly modify source files in this folder without having to reinstall the package for them to be taken into account.
+
+  This will install your local fork in editable mode, meaning you can directly modify source files in this folder without having to reinstall the package for them to be taken into account. Note the option `--recurse-submodules` needed to donwload the submodules required to run the tests.
 
 - Open a branch for your developments:
+
   ```bash
   git checkout -b name-that-describes-my-feature
   ```
 
 - Add your changes to the code using your favorite editor. You may at any moment test that everything is still working by running the test suite. From the root folder of the repository, run:
+
   ```bash
   pytest
   ```
 
 - Once you are happy with your modifications, commit them, and push your changes to GitHub:
+
   ```python
   git add file_I_changed.py
   git commit -m "a message that describes your modifications"
   git push -set-upstream origin name-that-describes-my-feature
   ```
 
-- From your GitHub interface, you should now be able to open a Pull Request to the JAX-GalSim repository. 
+- From your GitHub interface, you should now be able to open a Pull Request to the JAX-GalSim repository.
 
 Before submitting your PR, have a look at the procedure documented below.
 
@@ -48,6 +51,7 @@ Before submitting your PR, have a look at the procedure documented below.
 - Pull Requests should be self-contained and limited in scope, otherwise they become too difficult to review. If your modifications are broad, consider opening several smaller Pull Requests.
 
 - Make sure your fork and branch are up-to-date with the `main` branch of JAX-GalSim. To update your local branch, you may do so from the GitHub interface, or you may use this CLI command:
+
   ```bash
   # Only needs to be done once:
   git remote add upstream http://www.github.com/GalSim-developers/JAX-GalSim
@@ -57,15 +61,19 @@ Before submitting your PR, have a look at the procedure documented below.
   ```
 
 - Make sure the unit tests still work:
+
   ```bash
   pytest
   ```
+
   Ideally there should be some new unit tests for the new functionality, unless the work is completely covered by existing unit tests.
 
 - Make sure your code conforms to the [Black](https://github.com/psf/black) style:
+
   ```bash
   black .
   ```
+
   If you haven't installed it already, you can install Black with `pip install black`.
 
 - Update CHANGELOG.md to mention your change.
@@ -73,6 +81,7 @@ Before submitting your PR, have a look at the procedure documented below.
 - Make sure any new files have BSD license at the top.
 
 - If your changes contain multiple commits, we encourage you to squash them into a single (or very few) commit, before opening the PR. To do so, you can using this command:
+
 ```bash
 git rebase -i
 ```
@@ -105,20 +114,23 @@ git rebase -i
 
 ### Code Style
 
-In this project we follow the [Black](https://github.com/psf/black) code formatting guidelines` (Any color you like...) This means that all code should be automatically formatted using Black and CI will fail if that's not the case. 
+In this project we follow the [Black](https://github.com/psf/black) code formatting guidelines` (Any color you like...) This means that all code should be automatically formatted using Black and CI will fail if that's not the case.
 
 You can install Black locally like so:
+
 ```bash
-pip install black 
+pip install black
 ```
+
 And run it manually from the root directory of your local clone with `black .`
 
 We highly recommend installing `pre-commit`, which will take care of running Black for you before any commit you make:
+
 ```bash
 pip install pre-commit
 ```
-And that's all you need to do from now on.
 
+And that's all you need to do from now on.
 
 ### Documentation style
 
@@ -131,7 +143,7 @@ import galsim as _galsim
 from jax._src.numpy.util import _wraps
 from jax.tree_util import register_pytree_node_class
 
-@_wraps(_galsim.Add, 
+@_wraps(_galsim.Add,
         lax_description="Does not support `ChromaticObject` at this point.")
 def Add(*args, **kwargs):
     return Sum(*args, **kwargs)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The goal of this library is to reimplement GalSim functionalities in pure JAX to
 
 ## Contributing
 
-Everyone can contribute to this project, please refer to the CONTRIBUTING.md document for details. 
+Everyone can contribute to this project, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) document for details. 
 
 In short, to interact with the project you can:
 - Ask or Answer questions on the [Discussions Q&A](https://github.com/GalSim-developers/JAX-GalSim/discussions/categories/q-a) page

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # JAX-GalSim
-JAX port of GalSim, for parallelized, GPU accelerated, and differentiable galaxy image simulations.
+
+**JAX port of GalSim, for parallelized, GPU accelerated, and differentiable galaxy image simulations.**
+
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
 
 **Disclaimer**: This project is still in an early development phase, **please use the [reference GalSim implementation](https://github.com/GalSim-developers/GalSim) for any scientific applications.**
 
@@ -7,29 +10,30 @@ JAX port of GalSim, for parallelized, GPU accelerated, and differentiable galaxy
 
 See [design document](https://docs.google.com/document/d/1NalCc_5dc3Z8F4q37y-RsJS_mr9gzvfyANb2PYUpsb4/edit?usp=sharing).
 
-The goal of this library is to reimplement GalSim functionalities in pure JAX to allow for automatic differentiation, GPU acceleration, and batched computations. 
+The goal of this library is to reimplement GalSim functionalities in pure JAX to allow for automatic differentiation, GPU acceleration, and batched computations.
 
 **Guiding Principles**:
+
 - Strive to be a drop-in replacement for GalSim, i.e. provide a close match to the GalSim API.
 - Each function/feature will be tested against the reference GalSim implementation.
-- This package will aim to be a **subset** of GalSim (i.e. only contains functions with a reference GalSim implementation). 
-- Implementations should be easy to read and understand. 
+- This package will aim to be a **subset** of GalSim (i.e. only contains functions with a reference GalSim implementation).
+- Implementations should be easy to read and understand.
 - Code should be pip installable on any machine, no compilation required.
 - Any notable differences between the JAX and reference implementations will be clearly documented.
 
-
 ## Contributing
 
-Everyone can contribute to this project, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) document for details. 
+Everyone can contribute to this project, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) document for details.
 
 In short, to interact with the project you can:
+
 - Ask or Answer questions on the [Discussions Q&A](https://github.com/GalSim-developers/JAX-GalSim/discussions/categories/q-a) page
 - Report a bug by opening a [GitHub issue](https://github.com/GalSim-developers/JAX-GalSim/issues)
 - Open a [GitHub issue](https://github.com/GalSim-developers/JAX-GalSim/issues) or [Discussions](https://github.com/GalSim-developers/JAX-GalSim/discussions) to ask for feedback on a planned contribution.
 - Submit a Pull Request to contribute to the code.
 
-Issues marked with *contributions welcome* or *good first issue* are particularly good places to start. These are great ways to learn more 
-about the inner workings of GalSim and how to code in JAX. 
+Issues marked with _contributions welcome_ or _good first issue_ are particularly good places to start. These are great ways to learn more
+about the inner workings of GalSim and how to code in JAX.
 
 ## Current GalSim capabilities coverage
 


### PR DESCRIPTION
This PR proposes a set of contributing guidelines which draw in large part from the GalSim guidelines as documented in the GalSim wiki. This could be repurposed for GalSim as well.

One interesting question, is that I didn't find a reference to a **Code Of Conduct** in the original GalSim, which would be pretty good to have in general for all GalSim-developers projects. As a starting point, I've proposed language to point to the [Astropy Code of Conduct](https://www.astropy.org/code_of_conduct.html), which it not ideal as-is because this code references a confidential contact email to report any problems, which we don't currently have. So I think it would be pretty nice to develop a slightly adjusted version for GalSim-developers. I'll let @rmandelb @rmjarvis comment on that.

In terms of recovering/recapturing practices from the GalSim project, here is where I drew content from:
- [GalSim Developer Information](https://github.com/GalSim-developers/GalSim/wiki/Developer-Information): Appears to be mostly outdated, but contains explanations about git workflow that I didn't recapture here because it seemed a bit redundant.

- [GalSim Pull Request Checklist](https://github.com/GalSim-developers/GalSim/wiki/Checklist-for-making-a-pull-request): Here I have copied a number of things, but ignored all references to scons, code style, python 2, and doc update (since in the present case, documentation is inherited from GalSim mostly)

- [Checklist for new tagged release](https://github.com/GalSim-developers/GalSim/wiki/Checklist-for-making-a-new-tagged-release): most of these things will be different, a lot of it will be automated, so didn't recapture its content for now.