### PR TITLE
Vmap bug fix on GSObjects (Gaussian, Exponential)

### DIFF
--- a/jax_galsim/__init__.py
+++ b/jax_galsim/__init__.py
@@ -27,19 +27,6 @@ from jax_galsim.exponential import Exponential
 from jax_galsim.gaussian import Gaussian
 from jax_galsim.gsobject import GSObject
 
-# Image
-from .image import (
-    Image,
-    ImageS,
-    ImageI,
-    ImageF,
-    ImageD,
-    ImageCF,
-    ImageCD,
-    ImageUS,
-    ImageUI,
-)
-
 # GSObject
 from jax_galsim.gsparams import GSParams
 

--- a/jax_galsim/__init__.py
+++ b/jax_galsim/__init__.py
@@ -27,6 +27,19 @@ from jax_galsim.exponential import Exponential
 from jax_galsim.gaussian import Gaussian
 from jax_galsim.gsobject import GSObject
 
+# Image
+from .image import (
+    Image,
+    ImageS,
+    ImageI,
+    ImageF,
+    ImageD,
+    ImageCF,
+    ImageCD,
+    ImageUS,
+    ImageUI,
+)
+
 # GSObject
 from jax_galsim.gsparams import GSParams
 

--- a/jax_galsim/bounds.py
+++ b/jax_galsim/bounds.py
@@ -1,10 +1,9 @@
-import jax.numpy as jnp
-
-from jax_galsim.position import Position, PositionD, PositionI
-
 import galsim as _galsim
+import jax.numpy as jnp
 from jax._src.numpy.util import _wraps
 from jax.tree_util import register_pytree_node_class
+
+from jax_galsim.position import Position, PositionD, PositionI
 
 
 # The reason for avoid these tests is that they are not easy to do for jitted code.

--- a/jax_galsim/bounds.py
+++ b/jax_galsim/bounds.py
@@ -202,10 +202,6 @@ class BoundsD(Bounds):
 
     def __init__(self, *args, **kwargs):
         self._parse_args(*args, **kwargs)
-        self.xmin = jnp.asarray(self.xmin).astype("float")
-        self.xmax = jnp.asarray(self.xmax).astype("float")
-        self.ymin = jnp.asarray(self.ymin).astype("float")
-        self.ymax = jnp.asarray(self.ymax).astype("float")
 
     def _check_scalar(self, x, name):
         try:
@@ -236,12 +232,7 @@ class BoundsI(Bounds):
 
     def __init__(self, *args, **kwargs):
         self._parse_args(*args, **kwargs)
-        # Now make sure they are all ints
-        self.xmin = jnp.asarray(self.xmin).astype("int")
-        self.xmax = jnp.asarray(self.xmax).astype("int")
-        self.ymin = jnp.asarray(self.ymin).astype("int")
-        self.ymax = jnp.asarray(self.ymax).astype("int")
-
+        
     def _check_scalar(self, x, name):
         try:
             if x == jnp.asarray(x).astype("int"):

--- a/jax_galsim/exponential.py
+++ b/jax_galsim/exponential.py
@@ -86,6 +86,7 @@ class Exponential(GSObject):
 
     def __str__(self):
         s = "galsim.Exponential(scale_radius=%s" % self.scale_radius
+        # if self.flux != 1.0:
         s += ", flux=%s" % self.flux
         s += ")"
         return s

--- a/jax_galsim/exponential.py
+++ b/jax_galsim/exponential.py
@@ -1,12 +1,11 @@
-import jax.numpy as jnp
-
-from jax_galsim.gsobject import GSObject
-from jax_galsim.gsparams import GSParams
-from jax_galsim.core.draw import draw_by_xValue
-
 import galsim as _galsim
+import jax.numpy as jnp
 from jax._src.numpy.util import _wraps
 from jax.tree_util import register_pytree_node_class
+
+from jax_galsim.core.draw import draw_by_xValue
+from jax_galsim.gsobject import GSObject
+from jax_galsim.gsparams import GSParams
 
 
 @_wraps(_galsim.Exponential)

--- a/jax_galsim/exponential.py
+++ b/jax_galsim/exponential.py
@@ -86,7 +86,6 @@ class Exponential(GSObject):
 
     def __str__(self):
         s = "galsim.Exponential(scale_radius=%s" % self.scale_radius
-        # if self.flux != 1.0:
         s += ", flux=%s" % self.flux
         s += ")"
         return s

--- a/jax_galsim/exponential.py
+++ b/jax_galsim/exponential.py
@@ -46,9 +46,11 @@ class Exponential(GSObject):
         else:
             super().__init__(scale_radius=scale_radius, flux=flux, gsparams=gsparams)
 
-        self._r0 = self.scale_radius
-        self._inv_r0 = 1.0 / self._r0
-        self._norm = self.flux * Exponential._inv_twopi * self._inv_r0**2
+        #Transfert to @property
+        #self._r0 = self.scale_radius
+        #self._inv_r0 = 1.0 / self._r0
+        #self._norm = self.flux * Exponential._inv_twopi * self._inv_r0**2
+
 
     @property
     def scale_radius(self):
@@ -57,6 +59,18 @@ class Exponential(GSObject):
             return self.params["half_light_radius"] / Exponential._hlr_factor
         else:
             return self.params["scale_radius"]
+    @property
+    def _r0(self):
+        return self.scale_radius
+
+    @property
+    def _inv_r0(self):
+        return 1.0 / self._r0
+
+    @property
+    def _norm(self):
+        return self.flux * Exponential._inv_twopi * self._inv_r0**2
+    
 
     @property
     def half_light_radius(self):
@@ -65,6 +79,7 @@ class Exponential(GSObject):
             return self.params["half_light_radius"]
         else:
             return self.params["scale_radius"] * Exponential._hlr_factor
+
 
     def __hash__(self):
         return hash(("galsim.Exponential", self.scale_radius, self.flux, self.gsparams))
@@ -78,8 +93,7 @@ class Exponential(GSObject):
 
     def __str__(self):
         s = "galsim.Exponential(scale_radius=%s" % self.scale_radius
-        if self.flux != 1.0:
-            s += ", flux=%s" % self.flux
+        s += ", flux=%s" % self.flux
         s += ")"
         return s
 

--- a/jax_galsim/exponential.py
+++ b/jax_galsim/exponential.py
@@ -46,12 +46,6 @@ class Exponential(GSObject):
         else:
             super().__init__(scale_radius=scale_radius, flux=flux, gsparams=gsparams)
 
-        #Transfert to @property
-        #self._r0 = self.scale_radius
-        #self._inv_r0 = 1.0 / self._r0
-        #self._norm = self.flux * Exponential._inv_twopi * self._inv_r0**2
-
-
     @property
     def scale_radius(self):
         """The scale radius of the profile."""
@@ -59,6 +53,7 @@ class Exponential(GSObject):
             return self.params["half_light_radius"] / Exponential._hlr_factor
         else:
             return self.params["scale_radius"]
+
     @property
     def _r0(self):
         return self.scale_radius
@@ -70,7 +65,6 @@ class Exponential(GSObject):
     @property
     def _norm(self):
         return self.flux * Exponential._inv_twopi * self._inv_r0**2
-    
 
     @property
     def half_light_radius(self):
@@ -79,7 +73,6 @@ class Exponential(GSObject):
             return self.params["half_light_radius"]
         else:
             return self.params["scale_radius"] * Exponential._hlr_factor
-
 
     def __hash__(self):
         return hash(("galsim.Exponential", self.scale_radius, self.flux, self.gsparams))

--- a/jax_galsim/gaussian.py
+++ b/jax_galsim/gaussian.py
@@ -58,9 +58,10 @@ class Gaussian(GSObject):
         else:
             super().__init__(sigma=sigma, flux=flux, gsparams=gsparams)
 
-        self._sigsq = self.sigma**2
-        self._inv_sigsq = 1.0 / self._sigsq
-        self._norm = self.flux * self._inv_sigsq * Gaussian._inv_twopi
+        #Transfert to @property
+        #self._sigsq = self.sigma**2
+        #self._inv_sigsq = 1.0 / self._sigsq
+        #self._norm = self.flux * self._inv_sigsq * Gaussian._inv_twopi
 
     @property
     def sigma(self):
@@ -82,6 +83,19 @@ class Gaussian(GSObject):
         """The FWHM of this Gaussian profile"""
         return self.sigma * Gaussian._fwhm_factor
 
+    @property
+    def _sigsq(self):
+        return self.sigma**2
+    
+    @property
+    def _inv_sigsq(self):
+        return  1.0 / self._sigsq
+
+    @property
+    def _norm(self):
+        return self.flux * self._inv_sigsq * Gaussian._inv_twopi
+    
+
     def __hash__(self):
         return hash(("galsim.Gaussian", self.sigma, self.flux, self.gsparams))
 
@@ -94,8 +108,7 @@ class Gaussian(GSObject):
 
     def __str__(self):
         s = "galsim.Gaussian(sigma=%s" % self.sigma
-        if self.flux != 1.0:
-            s += ", flux=%s" % self.flux
+        s += ", flux=%s" % self.flux
         s += ")"
         return s
 

--- a/jax_galsim/gaussian.py
+++ b/jax_galsim/gaussian.py
@@ -101,7 +101,6 @@ class Gaussian(GSObject):
 
     def __str__(self):
         s = "galsim.Gaussian(sigma=%s" % self.sigma
-        # if self.flux != 1.0:
         s += ", flux=%s" % self.flux
         s += ")"
         return s

--- a/jax_galsim/gaussian.py
+++ b/jax_galsim/gaussian.py
@@ -1,12 +1,11 @@
-import jax.numpy as jnp
-
-from jax_galsim.gsobject import GSObject
-from jax_galsim.gsparams import GSParams
-from jax_galsim.core.draw import draw_by_xValue
-
 import galsim as _galsim
+import jax.numpy as jnp
 from jax._src.numpy.util import _wraps
 from jax.tree_util import register_pytree_node_class
+
+from jax_galsim.core.draw import draw_by_xValue
+from jax_galsim.gsobject import GSObject
+from jax_galsim.gsparams import GSParams
 
 
 @_wraps(_galsim.Gaussian)
@@ -58,11 +57,6 @@ class Gaussian(GSObject):
         else:
             super().__init__(sigma=sigma, flux=flux, gsparams=gsparams)
 
-        #Transfert to @property
-        #self._sigsq = self.sigma**2
-        #self._inv_sigsq = 1.0 / self._sigsq
-        #self._norm = self.flux * self._inv_sigsq * Gaussian._inv_twopi
-
     @property
     def sigma(self):
         """The sigma of this Gaussian profile"""
@@ -86,15 +80,14 @@ class Gaussian(GSObject):
     @property
     def _sigsq(self):
         return self.sigma**2
-    
+
     @property
     def _inv_sigsq(self):
-        return  1.0 / self._sigsq
+        return 1.0 / self._sigsq
 
     @property
     def _norm(self):
         return self.flux * self._inv_sigsq * Gaussian._inv_twopi
-    
 
     def __hash__(self):
         return hash(("galsim.Gaussian", self.sigma, self.flux, self.gsparams))

--- a/jax_galsim/gaussian.py
+++ b/jax_galsim/gaussian.py
@@ -101,6 +101,7 @@ class Gaussian(GSObject):
 
     def __str__(self):
         s = "galsim.Gaussian(sigma=%s" % self.sigma
+        # if self.flux != 1.0:
         s += ", flux=%s" % self.flux
         s += ")"
         return s

--- a/jax_galsim/gsobject.py
+++ b/jax_galsim/gsobject.py
@@ -169,6 +169,11 @@ class GSObject:
         kpos = parse_pos_args(args, kwargs, "kx", "ky")
         return self._kValue(kpos)
 
+    @_wraps(_galsim.GSObject.kValue)
+    def kValue(self, *args, **kwargs):
+        kpos = parse_pos_args(args, kwargs, "kx", "ky")
+        return self._kValue(kpos)
+
     def _kValue(self, kpos):
         """Equivalent to `kValue`, but ``kpos`` must be a `galsim.PositionD` instance."""
         raise NotImplementedError("%s does not implement kValue" % self.__class__.__name__)

--- a/jax_galsim/gsobject.py
+++ b/jax_galsim/gsobject.py
@@ -151,7 +151,7 @@ class GSObject:
     @_wraps(_galsim.GSObject.xValue)
     def xValue(self, *args, **kwargs):
         pos = parse_pos_args(args, kwargs, "x", "y")
-        return self._xValue(pos.array)
+        return self._xValue(pos)
 
     def _xValue(self, pos):
         """Equivalent to `xValue`, but ``pos`` must be a PositionD.
@@ -172,7 +172,7 @@ class GSObject:
     @_wraps(_galsim.GSObject.kValue)
     def kValue(self, *args, **kwargs):
         kpos = parse_pos_args(args, kwargs, "kx", "ky")
-        return self._kValue(kpos.array)
+        return self._kValue(kpos)
 
     def _kValue(self, kpos):
         """Equivalent to `kValue`, but ``kpos`` must be a `galsim.PositionD` instance."""

--- a/jax_galsim/gsobject.py
+++ b/jax_galsim/gsobject.py
@@ -151,7 +151,7 @@ class GSObject:
     @_wraps(_galsim.GSObject.xValue)
     def xValue(self, *args, **kwargs):
         pos = parse_pos_args(args, kwargs, "x", "y")
-        return self._xValue(pos)
+        return self._xValue(pos.array)
 
     def _xValue(self, pos):
         """Equivalent to `xValue`, but ``pos`` must be a PositionD.
@@ -172,7 +172,7 @@ class GSObject:
     @_wraps(_galsim.GSObject.kValue)
     def kValue(self, *args, **kwargs):
         kpos = parse_pos_args(args, kwargs, "kx", "ky")
-        return self._kValue(kpos)
+        return self._kValue(kpos.array)
 
     def _kValue(self, kpos):
         """Equivalent to `kValue`, but ``kpos`` must be a `galsim.PositionD` instance."""

--- a/jax_galsim/gsobject.py
+++ b/jax_galsim/gsobject.py
@@ -174,6 +174,11 @@ class GSObject:
         kpos = parse_pos_args(args, kwargs, "kx", "ky")
         return self._kValue(kpos)
 
+    @_wraps(_galsim.GSObject.kValue)
+    def kValue(self, *args, **kwargs):
+        kpos = parse_pos_args(args, kwargs, "kx", "ky")
+        return self._kValue(kpos)
+
     def _kValue(self, kpos):
         """Equivalent to `kValue`, but ``kpos`` must be a `galsim.PositionD` instance."""
         raise NotImplementedError("%s does not implement kValue" % self.__class__.__name__)

--- a/jax_galsim/gsobject.py
+++ b/jax_galsim/gsobject.py
@@ -190,9 +190,7 @@ class GSObject:
         return _Transform(self, flux_ratio=flux_ratio)
 
     # Make sure the image is defined with the right size and wcs for drawImage()
-    def _setup_image(
-        self, image, nx, ny, bounds, add_to_image, dtype, center, odd=False
-    ):
+    def _setup_image(self, image, nx, ny, bounds, add_to_image, dtype, center, odd=False):
         from jax_galsim.bounds import BoundsI
         from jax_galsim.image import Image
 
@@ -253,9 +251,7 @@ class GSObject:
                         bounds=bounds,
                     )
                 if not bounds.isDefined():
-                    raise _galsim.GalSimValueError(
-                        "Cannot use undefined bounds", bounds
-                    )
+                    raise _galsim.GalSimValueError("Cannot use undefined bounds", bounds)
                 image = Image(bounds=bounds, dtype=dtype)
             elif nx is not None or ny is not None:
                 if nx is None or ny is None:
@@ -354,9 +350,7 @@ class GSObject:
                 offset += center - new_bounds.center
             else:
                 # Then will be created as even sized image.
-                offset += PositionD(
-                    center.x - jnp.ceil(center.x), center.y - jnp.ceil(center.y)
-                )
+                offset += PositionD(center.x - jnp.ceil(center.x), center.y - jnp.ceil(center.y))
         elif use_true_center:
             # For even-sized images, the SBProfile draw function centers the result in the
             # pixel just up and right of the real center.  So shift it back to make sure it really
@@ -448,9 +442,7 @@ class GSObject:
         new_bounds = self._get_new_bounds(image, nx, ny, bounds, center)
 
         # Get the local WCS, accounting for the offset correctly.
-        local_wcs = self._local_wcs(
-            wcs, image, offset, center, use_true_center, new_bounds
-        )
+        local_wcs = self._local_wcs(wcs, image, offset, center, use_true_center, new_bounds)
 
         # Account for area and exptime.
         flux_scale = area * exptime
@@ -507,9 +499,7 @@ class GSObject:
         the image's dtype must be either float32 or float64, and it must have a c_contiguous array
         (``image.iscontiguous`` must be True).
         """
-        raise NotImplementedError(
-            "%s does not implement drawReal" % self.__class__.__name__
-        )
+        raise NotImplementedError("%s does not implement drawReal" % self.__class__.__name__)
 
     def getGoodImageSize(self, pixel_scale):
         """Return a good size to use for drawing this profile.

--- a/jax_galsim/position.py
+++ b/jax_galsim/position.py
@@ -42,10 +42,6 @@ class Position(object):
             if kwargs:
                 raise TypeError("Got unexpected keyword arguments %s" % kwargs.keys())
 
-        # Make sure the inputs are indeed jax numpy values
-        self.x = jnp.asarray(self.x)
-        self.y = jnp.asarray(self.y)
-
     @property
     def array(self):
         """Return the position as a 2-element numpy array."""
@@ -134,8 +130,6 @@ class Position(object):
 class PositionD(Position):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.x = self.x.astype("float")
-        self.y = self.y.astype("float")
 
 
 @_wraps(_galsim.PositionI)
@@ -143,5 +137,3 @@ class PositionD(Position):
 class PositionI(Position):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.x = self.x.astype("int")
-        self.y = self.y.astype("int")

--- a/jax_galsim/sum.py
+++ b/jax_galsim/sum.py
@@ -1,12 +1,11 @@
-import numpy as np
-import jax.numpy as jnp
-
-from jax_galsim.gsparams import GSParams
-from jax_galsim.gsobject import GSObject
-
 import galsim as _galsim
+import jax.numpy as jnp
+import numpy as np
 from jax._src.numpy.util import _wraps
 from jax.tree_util import register_pytree_node_class
+
+from jax_galsim.gsobject import GSObject
+from jax_galsim.gsparams import GSParams
 
 
 @_wraps(_galsim.Add, lax_description="Does not support `ChromaticObject` at this point.")

--- a/jax_galsim/transform.py
+++ b/jax_galsim/transform.py
@@ -1,12 +1,11 @@
+import galsim as _galsim
 import jax.numpy as jnp
+from jax._src.numpy.util import _wraps
+from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.gsobject import GSObject
 from jax_galsim.gsparams import GSParams
 from jax_galsim.position import PositionD
-
-import galsim as _galsim
-from jax._src.numpy.util import _wraps
-from jax.tree_util import register_pytree_node_class
 
 
 @_wraps(
@@ -312,13 +311,7 @@ class Transformation(GSObject):
             dx += x1[0]
             dy += x1[1]
         flux_scaling *= self._flux_scaling
-        jac = (
-            self._jac
-            if jac is None
-            else jac
-            if self._jac is None
-            else jac.dot(self._jac)
-        )
+        jac = self._jac if jac is None else jac if self._jac is None else jac.dot(self._jac)
         return self._original._drawReal(image, jac, (dx, dy), flux_scaling)
 
     def tree_flatten(self):

--- a/jax_galsim/transform.py
+++ b/jax_galsim/transform.py
@@ -28,32 +28,6 @@ def Transform(
         return Transformation(obj, jac, offset, flux_ratio, gsparams, propagate_gsparams)
 
 
-@_wraps(
-    _galsim.Transform,
-    lax_description="Does not support Chromatic Objects or Convolutions.",
-)
-def Transform(
-    obj,
-    jac=(1.0, 0.0, 0.0, 1.0),
-    offset=PositionD(0.0, 0.0),
-    flux_ratio=1.0,
-    gsparams=None,
-    propagate_gsparams=True,
-):
-    if not (isinstance(obj, GSObject)):
-        raise TypeError("Argument to Transform must be a GSObject.")
-    elif (
-        hasattr(jac, "__call__")
-        or hasattr(offset, "__call__")
-        or hasattr(flux_ratio, "__call__")
-    ):
-        raise NotImplementedError("Transform does not support callable arguments.")
-    else:
-        return Transformation(
-            obj, jac, offset, flux_ratio, gsparams, propagate_gsparams
-        )
-
-
 @_wraps(_galsim.Transformation)
 @register_pytree_node_class
 class Transformation(GSObject):

--- a/jax_galsim/transform.py
+++ b/jax_galsim/transform.py
@@ -40,7 +40,6 @@ class Transformation(GSObject):
         gsparams=None,
         propagate_gsparams=True,
     ):
-        self._jac = jnp.asarray(jac, dtype=float).reshape(2, 2)
         self._offset = PositionD(offset)
         self._flux_ratio = flux_ratio
         self._gsparams = GSParams.check(gsparams, obj.gsparams)
@@ -50,7 +49,7 @@ class Transformation(GSObject):
 
         self._params = {
             "obj": obj,
-            "jac": self._jac,
+            "jac": jac,
             "offset": self._offset,
             "flux_ratio": self._flux_ratio,
         }
@@ -65,6 +64,10 @@ class Transformation(GSObject):
             self._original = obj.original
         else:
             self._original = obj
+
+    @property
+    def _jac(self):
+        return jnp.asarray(self._params["jac"], dtype=float).reshape(2, 2)
 
     @property
     def original(self):

--- a/jax_galsim/transform.py
+++ b/jax_galsim/transform.py
@@ -28,6 +28,32 @@ def Transform(
         return Transformation(obj, jac, offset, flux_ratio, gsparams, propagate_gsparams)
 
 
+@_wraps(
+    _galsim.Transform,
+    lax_description="Does not support Chromatic Objects or Convolutions.",
+)
+def Transform(
+    obj,
+    jac=(1.0, 0.0, 0.0, 1.0),
+    offset=PositionD(0.0, 0.0),
+    flux_ratio=1.0,
+    gsparams=None,
+    propagate_gsparams=True,
+):
+    if not (isinstance(obj, GSObject)):
+        raise TypeError("Argument to Transform must be a GSObject.")
+    elif (
+        hasattr(jac, "__call__")
+        or hasattr(offset, "__call__")
+        or hasattr(flux_ratio, "__call__")
+    ):
+        raise NotImplementedError("Transform does not support callable arguments.")
+    else:
+        return Transformation(
+            obj, jac, offset, flux_ratio, gsparams, propagate_gsparams
+        )
+
+
 @_wraps(_galsim.Transformation)
 @register_pytree_node_class
 class Transformation(GSObject):

--- a/jax_galsim/utilities.py
+++ b/jax_galsim/utilities.py
@@ -1,7 +1,7 @@
-from jax_galsim.position import PositionD, PositionI
-
 import galsim as _galsim
 from jax._src.numpy.util import _wraps
+
+from jax_galsim.position import PositionD, PositionI
 
 
 @_wraps(_galsim.utilities.parse_pos_args)

--- a/jax_galsim/wcs.py
+++ b/jax_galsim/wcs.py
@@ -526,8 +526,11 @@ class LocalWCS(UniformWCS):
 class PixelScale(LocalWCS):
     def __init__(self, scale):
         self._params = {"scale": scale}
-        self._scale = jnp.asarray(scale)
         self._color = None
+
+    @property
+    def _scale(self):
+        return jnp.asarray(self._params["scale"])
 
     # Help make sure PixelScale is read-only.
     @property
@@ -613,7 +616,10 @@ class JacobianWCS(LocalWCS):
     def __init__(self, dudx, dudy, dvdx, dvdy):
         self._color = None
         self._params = {"dudx": dudx, "dudy": dudy, "dvdx": dvdx, "dvdy": dvdy}
-        self._det = dudx * dvdy - dudy * dvdx
+
+    @property
+    def _det(self):
+        return self.dudx * self.dvdy - self.dudy * self.dvdx
 
     # Help make sure JacobianWCS is read-only.
     @property

--- a/tests/jax/test_image_jax.py
+++ b/tests/jax/test_image_jax.py
@@ -464,7 +464,7 @@ def test_Image_basic():
         dy = 16
         im1.shift(dx, dy)
         im2_view.setOrigin(1 + dx, 1 + dy)
-        im3_view.setCenter((ncol + 1) / 2 + dx, (nrow + 1) / 2 + dy)
+        im3_view.setCenter(int((ncol + 1) / 2 + dx), int((nrow + 1) / 2 + dy))
         shifted_bounds = galsim.BoundsI(1 + dx, ncol + dx, 1 + dy, nrow + dy)
 
         assert im1.bounds == shifted_bounds

--- a/tests/jax/test_jitting.py
+++ b/tests/jax/test_jitting.py
@@ -113,32 +113,3 @@ def test_position_jitting():
         return self.x == other.x and self.y == other.y
 
     assert test_eq(identity(obj), obj)
-
-
-def test_affine_transform_jitting():
-    obj = galsim.AffineTransform(
-        1.0,
-        0.0,
-        0.0,
-        1.0,
-        origin=galsim.PositionD(1.0, 2.0),
-        world_origin=galsim.PositionD(1.0, 2.0),
-    )
-
-    def test_eq(self, other):
-        return (
-            self._local_wcs == other._local_wcs
-            and self.origin == other.origin
-            and self.world_origin == other.world_origin
-        )
-
-    assert test_eq(identity(obj), obj)
-
-
-def test_bounds_jitting():
-    obj = galsim.BoundsD(0.0, 1.0, 0.0, 1.0)
-
-    objI = galsim.BoundsI(0.0, 1.0, 0.0, 1.0)
-
-    assert identity(obj) == obj
-    assert identity(objI) == objI

--- a/tests/jax/test_jitting.py
+++ b/tests/jax/test_jitting.py
@@ -104,3 +104,12 @@ def test_image_jitting():
     ).astype(dtype=jnp.float32)
     im1 = galsim.Image.init(ref_array, wcs=galsim.PixelScale(0.2), dtype=jnp.int32)
     assert identity(im1) == im1
+
+
+def test_position_jitting():
+    obj = galsim.PositionD(1.0, 2.0)
+
+    def test_eq(self, other):
+        return self.x == other.x and self.y == other.y
+
+    assert test_eq(identity(obj), obj)

--- a/tests/jax/test_jitting.py
+++ b/tests/jax/test_jitting.py
@@ -113,3 +113,23 @@ def test_position_jitting():
         return self.x == other.x and self.y == other.y
 
     assert test_eq(identity(obj), obj)
+
+
+def test_affine_transform_jitting():
+    obj = galsim.AffineTransform(
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        origin=galsim.PositionD(1.0, 2.0),
+        world_origin=galsim.PositionD(1.0, 2.0),
+    )
+
+    def test_eq(self, other):
+        return (
+            self._local_wcs == other._local_wcs
+            and self.origin == other.origin
+            and self.world_origin == other.world_origin
+        )
+
+    assert test_eq(identity(obj), obj)

--- a/tests/jax/test_jitting.py
+++ b/tests/jax/test_jitting.py
@@ -133,3 +133,12 @@ def test_affine_transform_jitting():
         )
 
     assert test_eq(identity(obj), obj)
+
+
+def test_bounds_jitting():
+    obj = galsim.BoundsD(0.0, 1.0, 0.0, 1.0)
+
+    objI = galsim.BoundsI(0.0, 1.0, 0.0, 1.0)
+
+    assert identity(obj) == obj
+    assert identity(objI) == objI

--- a/tests/jax/test_vmapping.py
+++ b/tests/jax/test_vmapping.py
@@ -1,0 +1,109 @@
+import jax
+import jax.numpy as jnp
+
+import jax_galsim as galsim
+
+e = jnp.ones(2)
+
+
+def duplicate(params):
+    return {x: y * e for x, y in params.items()}
+
+
+def test_gaussian_vmapping():
+    # Test Gaussian objects
+    objects = [
+        galsim.Gaussian(half_light_radius=1.0, flux=0.2),
+        galsim.Gaussian(sigma=0.1, flux=0.2),
+        galsim.Gaussian(fwhm=1.0, flux=0.2),
+    ]
+
+    # Test equality function from original galsim gaussian.py
+    def test_eq(self, other):
+        return (self.sigma == jnp.array([other.sigma, other.sigma])).all() and (
+            self.flux == jnp.array([other.flux, other.flux])
+        ).all()
+
+    # Check that after vmapping the oject is still the same
+    assert all([test_eq(jax.vmap(galsim.Gaussian)(**duplicate(o.params)), o) for o in objects])
+
+
+def test_exponential_vmapping():
+    # Test Exponential objects
+    objects = [
+        galsim.Exponential(half_light_radius=1.0, flux=0.2),
+        galsim.Exponential(scale_radius=0.1, flux=0.2),
+    ]
+
+    # Test equality function from original galsim exponential.py
+    def test_eq(self, other):
+        return (
+            self.scale_radius == jnp.array([other.scale_radius, other.scale_radius])
+        ).all() and (self.flux == jnp.array([other.flux, other.flux])).all()
+
+    # Check that after vmapping the oject is still the same
+    assert all([test_eq(jax.vmap(galsim.Exponential)(**duplicate(o.params)), o) for o in objects])
+
+
+def eq_pos(pos, other):
+    return (pos.x == jnp.array([other.x, other.x])).all() and (
+        pos.y == jnp.array([other.y, other.y])
+    ).all()
+
+
+def test_position_vmapping():
+    obj = galsim.PositionD(1.0, 2.0)
+
+    assert eq_pos(jax.vmap(galsim.PositionD)(1.0 * e, 2.0 * e), obj)
+
+
+def test_affine_transform_vmapping():
+    obj = galsim.AffineTransform(
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        origin=galsim.PositionD(1.0, 2.0),
+        world_origin=galsim.PositionD(1.0, 2.0),
+    )
+
+    print("now vmap")
+
+    obj_duplicated = jax.vmap(galsim.AffineTransform)(
+        1.0 * e,
+        0.0 * e,
+        0.0 * e,
+        1.0 * e,
+        origin=jax.vmap(galsim.PositionD)(1.0 * e, 2.0 * e),
+        world_origin=jax.vmap(galsim.PositionD)(1.0 * e, 2.0 * e),
+    )
+
+    def test_eq(self, other):
+        return (
+            (
+                self._local_wcs.dudx == jnp.array([other._local_wcs.dudx, other._local_wcs.dudx])
+            ).all()
+            and eq_pos(self.origin, other.origin)
+            and eq_pos(self.world_origin, other.world_origin)
+        )
+
+    assert test_eq(obj_duplicated, obj)
+
+
+def test_bounds_vmapping():
+    obj = galsim.BoundsD(0.0, 1.0, 0.0, 1.0)
+    obj_d = jax.vmap(galsim.BoundsD)(0.0 * e, 1.0 * e, 0.0 * e, 1.0 * e)
+
+    objI = galsim.BoundsI(0.0, 1.0, 0.0, 1.0)
+    objI_d = jax.vmap(galsim.BoundsI)(0.0 * e, 1.0 * e, 0.0 * e, 1.0 * e)
+
+    def test_eq(self, other):
+        return (
+            (self.xmin == jnp.array([other.xmin, other.xmin])).all()
+            and (self.xmax == jnp.array([other.xmax, other.xmax])).all()
+            and (self.ymin == jnp.array([other.ymin, other.ymin])).all()
+            and (self.ymax == jnp.array([other.ymax, other.ymax])).all()
+        )
+
+    assert test_eq(obj_d, obj)
+    assert test_eq(objI_d, objI)


### PR DESCRIPTION
This is related to some vmap crashes due to variable initializations. Issue #31
This PR is to be able to perform
```python
fluxes = jnp.array([1.e5, 2.e5])
sigmas = jnp.array([1.,2.])

catalog = galsim.Gaussian(flux=fluxes,sigma=sigmas)
print(catalog)
print("maxk of gal: ",jax.vmap(lambda g: g.maxk)(catalog))
print("hlr of gal: ",jax.vmap(lambda g: g.half_light_radius)(catalog))
print("xVal :",jax.vmap(lambda g: g._xValue(galsim.PositionD(0.1,0.1)))(catalog))
print("kVal :",jax.vmap(lambda g: g._kValue(galsim.PositionD(0.1,0.1)))(catalog))


scale_radius = jnp.array([1.,2.])
catalog = galsim.Exponential(flux=fluxes,scale_radius=scale_radius)
print(catalog)
print("maxk of gal: ",jax.vmap(lambda x: x.maxk)(catalog))
print("hlr of gal: ",jax.vmap(lambda x: x.half_light_radius)(catalog))
print("xVal :",jax.vmap(lambda g: g._xValue(galsim.PositionD(0.1,0.1)))(catalog))
print("kVal :",jax.vmap(lambda g: g._kValue(galsim.PositionD(0.1,0.1)))(catalog))
``` 
 