### PR TITLE
Restoring canonical GalSim Image API

### DIFF
--- a/jax_galsim/core/draw.py
+++ b/jax_galsim/core/draw.py
@@ -5,7 +5,9 @@ from jax_galsim import Image, PositionD
 
 
 @jax.jit
-def draw_by_xValue(gsobject, image, jacobian=jnp.eye(2), offset=jnp.zeros(2), flux_scaling=1.0):
+def draw_by_xValue(
+    gsobject, image, jacobian=jnp.eye(2), offset=jnp.zeros(2), flux_scaling=1.0
+):
     """Utility function to draw a real-space GSObject into an Image."""
     # Applies flux scaling to compensate for pixel scale
     # See SBProfile.draw()
@@ -24,10 +26,12 @@ def draw_by_xValue(gsobject, image, jacobian=jnp.eye(2), offset=jnp.zeros(2), fl
     flux_scaling *= jnp.exp(logdet)
 
     # Draw the object
-    im = jax.vmap(lambda *args: gsobject._xValue(PositionD(*args)))(coords[..., 0], coords[..., 1])
+    im = jax.vmap(lambda *args: gsobject._xValue(PositionD(*args)))(
+        coords[..., 0], coords[..., 1]
+    )
 
     # Apply the flux scaling
     im = (im * flux_scaling).astype(image.dtype)
 
     # Return an image
-    return Image(_array=im, _bounds=image.bounds, wcs=image.wcs, _dtype=image.dtype)
+    return Image(array=im, bounds=image.bounds, wcs=image.wcs, check_bounds=False)

--- a/jax_galsim/gsobject.py
+++ b/jax_galsim/gsobject.py
@@ -162,7 +162,9 @@ class GSObject:
         Returns:
             the surface brightness at that position.
         """
-        raise NotImplementedError("%s does not implement xValue" % self.__class__.__name__)
+        raise NotImplementedError(
+            "%s does not implement xValue" % self.__class__.__name__
+        )
 
     @_wraps(_galsim.GSObject.kValue)
     def kValue(self, *args, **kwargs):
@@ -171,7 +173,9 @@ class GSObject:
 
     def _kValue(self, kpos):
         """Equivalent to `kValue`, but ``kpos`` must be a `galsim.PositionD` instance."""
-        raise NotImplementedError("%s does not implement kValue" % self.__class__.__name__)
+        raise NotImplementedError(
+            "%s does not implement kValue" % self.__class__.__name__
+        )
 
     def withGSParams(self, gsparams=None, **kwargs):
         """Create a version of the current object with the given `GSParams`."""
@@ -214,9 +218,13 @@ class GSObject:
             shear = args[0]
         if len(args) == 1:
             if kwargs:
-                raise TypeError("Error, gave both unnamed and named arguments to GSObject.shear!")
+                raise TypeError(
+                    "Error, gave both unnamed and named arguments to GSObject.shear!"
+                )
             if not isinstance(args[0], Shear):
-                raise TypeError("Error, unnamed argument to GSObject.shear is not a Shear!")
+                raise TypeError(
+                    "Error, unnamed argument to GSObject.shear is not a Shear!"
+                )
             shear = args[0]
         elif len(args) > 1:
             raise TypeError("Error, too many unnamed arguments to GSObject.shear!")
@@ -243,7 +251,9 @@ class GSObject:
         return _Transform(self, shear.getMatrix())
 
     # Make sure the image is defined with the right size and wcs for drawImage()
-    def _setup_image(self, image, nx, ny, bounds, add_to_image, dtype, center, odd=False):
+    def _setup_image(
+        self, image, nx, ny, bounds, add_to_image, dtype, center, odd=False
+    ):
         from jax_galsim.bounds import BoundsI
         from jax_galsim.image import Image
 
@@ -304,14 +314,16 @@ class GSObject:
                         bounds=bounds,
                     )
                 if not bounds.isDefined():
-                    raise _galsim.GalSimValueError("Cannot use undefined bounds", bounds)
-                image = Image.init(bounds=bounds, dtype=dtype)
+                    raise _galsim.GalSimValueError(
+                        "Cannot use undefined bounds", bounds
+                    )
+                image = Image(bounds=bounds, dtype=dtype)
             elif nx is not None or ny is not None:
                 if nx is None or ny is None:
                     raise _galsim.GalSimIncompatibleValuesError(
                         "Must set either both or neither of nx, ny", nx=nx, ny=ny
                     )
-                image = Image.init(nx, ny, dtype=dtype)
+                image = Image(nx, ny, dtype=dtype)
                 if center is not None:
                     image.shift(
                         PositionI(
@@ -323,7 +335,7 @@ class GSObject:
                 N = self.getGoodImageSize(1.0)
                 if odd:
                     N += 1
-                image = Image.init(N, N, dtype=dtype)
+                image = Image(N, N, dtype=dtype)
                 if center is not None:
                     image.setCenter(PositionI(jnp.ceil(center.x), jnp.ceil(center.y)))
 
@@ -403,7 +415,9 @@ class GSObject:
                 offset += center - new_bounds.center
             else:
                 # Then will be created as even sized image.
-                offset += PositionD(center.x - jnp.ceil(center.x), center.y - jnp.ceil(center.y))
+                offset += PositionD(
+                    center.x - jnp.ceil(center.x), center.y - jnp.ceil(center.y)
+                )
         elif use_true_center:
             # For even-sized images, the SBProfile draw function centers the result in the
             # pixel just up and right of the real center.  So shift it back to make sure it really
@@ -495,7 +509,9 @@ class GSObject:
         new_bounds = self._get_new_bounds(image, nx, ny, bounds, center)
 
         # Get the local WCS, accounting for the offset correctly.
-        local_wcs = self._local_wcs(wcs, image, offset, center, use_true_center, new_bounds)
+        local_wcs = self._local_wcs(
+            wcs, image, offset, center, use_true_center, new_bounds
+        )
 
         # Account for area and exptime.
         flux_scale = area * exptime
@@ -552,7 +568,9 @@ class GSObject:
         the image's dtype must be either float32 or float64, and it must have a c_contiguous array
         (``image.iscontiguous`` must be True).
         """
-        raise NotImplementedError("%s does not implement drawReal" % self.__class__.__name__)
+        raise NotImplementedError(
+            "%s does not implement drawReal" % self.__class__.__name__
+        )
 
     def getGoodImageSize(self, pixel_scale):
         """Return a good size to use for drawing this profile.

--- a/jax_galsim/image.py
+++ b/jax_galsim/image.py
@@ -943,14 +943,18 @@ class Image(object):
         """Flatten the image into a list of values."""
         # Define the children nodes of the PyTree that need tracing
         children = (self.array, self.wcs, self.bounds)
-        return (children, None)
+        aux_data = {"dtype": self.dtype}
+        return (children, aux_data)
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
         """Recreates an instance of the class from flatten representation"""
-        return cls(
-            array=children[0], wcs=children[1], bounds=children[2], check_bounds=False
-        )
+        obj = object.__new__(cls)
+        obj._array = children[0]
+        obj.wcs = children[1]
+        obj._bounds = children[2]
+        obj._dtype = aux_data["dtype"]
+        return obj
 
 
 # These are essentially aliases for the regular Image with the correct dtype

--- a/jax_galsim/position.py
+++ b/jax_galsim/position.py
@@ -120,7 +120,7 @@ class Position(object):
             a `galsim.PositionD` instance.
         """
         shear_mat = shear.getMatrix()
-        shear_pos = jnp.dot(shear_mat, self.array)
+        shear_pos = jnp.dot(shear_mat, jnp.stack([self.x, self.y], axis=0))
         return PositionD(shear_pos[0], shear_pos[1])
 
     def tree_flatten(self):
@@ -133,7 +133,11 @@ class Position(object):
     @classmethod
     def tree_unflatten(cls, aux_data, children):
         """Recreates an instance of the class from flatten representation"""
-        return cls(x=children[0], y=children[1])
+        del aux_data
+        obj = object.__new__(cls)
+        obj.x = children[0]
+        obj.y = children[1]
+        return obj
 
 
 @_wraps(_galsim.PositionD)

--- a/jax_galsim/position.py
+++ b/jax_galsim/position.py
@@ -120,7 +120,7 @@ class Position(object):
             a `galsim.PositionD` instance.
         """
         shear_mat = shear.getMatrix()
-        shear_pos = jnp.dot(shear_mat, jnp.stack([self.x, self.y], axis=0))
+        shear_pos = jnp.dot(shear_mat, self.array)
         return PositionD(shear_pos[0], shear_pos[1])
 
     def tree_flatten(self):

--- a/jax_galsim/position.py
+++ b/jax_galsim/position.py
@@ -26,7 +26,8 @@ class Position(object):
                         )
             else:
                 raise TypeError(
-                    "%s takes at most 2 arguments (%d given)" % (self.__class__, len(args))
+                    "%s takes at most 2 arguments (%d given)"
+                    % (self.__class__, len(args))
                 )
         elif len(args) != 0:
             raise TypeError(
@@ -38,9 +39,15 @@ class Position(object):
                 self.x = kwargs.pop("x")
                 self.y = kwargs.pop("y")
             except KeyError:
-                raise TypeError("Keyword arguments x,y are required for %s" % self.__class__)
+                raise TypeError(
+                    "Keyword arguments x,y are required for %s" % self.__class__
+                )
             if kwargs:
                 raise TypeError("Got unexpected keyword arguments %s" % kwargs.keys())
+
+        # Make sure the inputs are indeed jax numpy values
+        self.x = jnp.asarray(self.x)
+        self.y = jnp.asarray(self.y)
 
     @property
     def array(self):
@@ -74,7 +81,9 @@ class Position(object):
 
     def __sub__(self, other):
         if not isinstance(other, Position):
-            raise TypeError("Can only subtract a Position from a %s" % self.__class__.__name__)
+            raise TypeError(
+                "Can only subtract a Position from a %s" % self.__class__.__name__
+            )
         elif isinstance(other, self.__class__):
             return self.__class__(self.x - other.x, self.y - other.y)
         else:
@@ -88,7 +97,9 @@ class Position(object):
 
     def __eq__(self, other):
         return self is other or (
-            isinstance(other, self.__class__) and self.x == other.x and self.y == other.y
+            isinstance(other, self.__class__)
+            and self.x == other.x
+            and self.y == other.y
         )
 
     def __ne__(self, other):
@@ -109,7 +120,7 @@ class Position(object):
             a `galsim.PositionD` instance.
         """
         shear_mat = shear.getMatrix()
-        shear_pos = jnp.dot(shear_mat, self.array)
+        shear_pos = jnp.dot(shear_mat, jnp.stack([self.x, self.y], axis=0))
         return PositionD(shear_pos[0], shear_pos[1])
 
     def tree_flatten(self):
@@ -130,6 +141,8 @@ class Position(object):
 class PositionD(Position):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.x = self.x.astype("float")
+        self.y = self.y.astype("float")
 
 
 @_wraps(_galsim.PositionI)
@@ -137,3 +150,5 @@ class PositionD(Position):
 class PositionI(Position):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.x = self.x.astype("int")
+        self.y = self.y.astype("int")

--- a/jax_galsim/wcs.py
+++ b/jax_galsim/wcs.py
@@ -329,9 +329,13 @@ class EuclideanWCS(BaseWCS):
 
         else:
             if not isinstance(world_origin, Position):
-                raise TypeError("world_origin must be a PositionD or PositionI argument")
+                raise TypeError(
+                    "world_origin must be a PositionD or PositionI argument"
+                )
             if not self._isLocal:
-                world_origin += self.world_origin - self._posToWorld(self.origin, color=color)
+                world_origin += self.world_origin - self._posToWorld(
+                    self.origin, color=color
+                )
             return self._newOrigin(origin, world_origin)
 
     # If the class doesn't define something else, then we can approximate the local Jacobian
@@ -369,7 +373,9 @@ class EuclideanWCS(BaseWCS):
     # numpy arrays!
     def _makeSkyImage(self, image, sky_level, color):
         b = image.bounds
-        nx = b.xmax - b.xmin + 1 + 2  # +2 more than in image to get row/col off each edge.
+        nx = (
+            b.xmax - b.xmin + 1 + 2
+        )  # +2 more than in image to get row/col off each edge.
         ny = b.ymax - b.ymin + 1 + 2
         x, y = jnp.meshgrid(
             jnp.linspace(b.xmin - 1, b.xmax + 1, nx),
@@ -525,12 +531,12 @@ class LocalWCS(UniformWCS):
 @register_pytree_node_class
 class PixelScale(LocalWCS):
     def __init__(self, scale):
-        self._params = {"scale": scale}
+        self._params = {"scale": jnp.float64(scale)}
         self._color = None
 
     @property
     def _scale(self):
-        return jnp.asarray(self._params["scale"])
+        return self._params["scale"]
 
     # Help make sure PixelScale is read-only.
     @property
@@ -601,7 +607,9 @@ class PixelScale(LocalWCS):
         return PixelScale(self._scale)
 
     def __eq__(self, other):
-        return self is other or (isinstance(other, PixelScale) and self.scale == other.scale)
+        return self is other or (
+            isinstance(other, PixelScale) and self.scale == other.scale
+        )
 
     def __repr__(self):
         return "galsim.PixelScale(%r)" % self.scale
@@ -664,10 +672,16 @@ class ShearWCS(LocalWCS):
         return y
 
     def _profileToWorld(self, image_profile, flux_ratio, offset):
-        return image_profile.dilate(self._scale).shear(-self.shear).shift(offset) * flux_ratio
+        return (
+            image_profile.dilate(self._scale).shear(-self.shear).shift(offset)
+            * flux_ratio
+        )
 
     def _profileToImage(self, world_profile, flux_ratio, offset):
-        return world_profile.dilate(1.0 / self._scale).shear(self.shear).shift(offset) * flux_ratio
+        return (
+            world_profile.dilate(1.0 / self._scale).shear(self.shear).shift(offset)
+            * flux_ratio
+        )
 
     def _pixelArea(self):
         return self._scale**2
@@ -700,7 +714,9 @@ class ShearWCS(LocalWCS):
 
     def __eq__(self, other):
         return self is other or (
-            isinstance(other, ShearWCS) and self.scale == other.scale and self.shear == other.shear
+            isinstance(other, ShearWCS)
+            and self.scale == other.scale
+            and self.shear == other.shear
         )
 
     def __repr__(self):
@@ -839,7 +855,9 @@ class JacobianWCS(LocalWCS):
         return JacobianWCS(dudx, dudy, dvdx, dvdy)
 
     def _newOrigin(self, origin, world_origin):
-        return AffineTransform(self.dudx, self.dudy, self.dvdx, self.dvdy, origin, world_origin)
+        return AffineTransform(
+            self.dudx, self.dudy, self.dvdx, self.dvdy, origin, world_origin
+        )
 
     def copy(self):
         return JacobianWCS(self.dudx, self.dudy, self.dvdx, self.dvdy)
@@ -1103,10 +1121,14 @@ class AffineTransform(UniformWCS):
         u0 = header.get("CRVAL1", 0.0)
         v0 = header.get("CRVAL2", 0.0)
 
-        return AffineTransform(dudx, dudy, dvdx, dvdy, PositionD(x0, y0), PositionD(u0, v0))
+        return AffineTransform(
+            dudx, dudy, dvdx, dvdy, PositionD(x0, y0), PositionD(u0, v0)
+        )
 
     def _newOrigin(self, origin, world_origin):
-        return AffineTransform(self.dudx, self.dudy, self.dvdx, self.dvdy, origin, world_origin)
+        return AffineTransform(
+            self.dudx, self.dudy, self.dvdx, self.dvdy, origin, world_origin
+        )
 
     def copy(self):
         return AffineTransform(
@@ -1114,7 +1136,9 @@ class AffineTransform(UniformWCS):
         )
 
     def __repr__(self):
-        return ("galsim.AffineTransform(%r, %r, %r, %r, origin=%r, world_origin=%r)") % (
+        return (
+            "galsim.AffineTransform(%r, %r, %r, %r, origin=%r, world_origin=%r)"
+        ) % (
             self.dudx,
             self.dudy,
             self.dvdx,

--- a/jax_galsim/wcs.py
+++ b/jax_galsim/wcs.py
@@ -531,7 +531,7 @@ class LocalWCS(UniformWCS):
 @register_pytree_node_class
 class PixelScale(LocalWCS):
     def __init__(self, scale):
-        self._params = {"scale": jnp.float64(scale)}
+        self._params = {"scale": scale}
         self._color = None
 
     @property

--- a/tests/jax/test_image_jax.py
+++ b/tests/jax/test_image_jax.py
@@ -3369,7 +3369,11 @@ def test_Image_view():
     assert_raises(
         TypeError, im.view, scale=0.3, wcs=galsim.JacobianWCS(1.1, 0.1, 0.1, 1.0)
     )
-    assert_raises(TypeError, im.view, scale=galsim.PixelScale(0.3))
+    # JAX specific modification
+    # -------------------------
+    # this test cannot work in JAX because during the tracing process
+    # a PixelScale object may be given to the WCS init function
+    # assert_raises(TypeError, im.view, scale=galsim.PixelScale(0.3))
     assert_raises(TypeError, im.view, wcs=0.3)
 
 

--- a/tests/jax/test_image_jax.py
+++ b/tests/jax/test_image_jax.py
@@ -44,16 +44,18 @@ incremented by one.
 """
 
 from __future__ import print_function
-
 import os
 import sys
 from unicodedata import decimal
 
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), "../GalSim/tests")))
-import galsim
+sys.path.insert(
+    1, os.path.abspath(os.path.join(os.path.dirname(__file__), "../GalSim/tests"))
+)
 import numpy as np
-from galsim._pyfits import pyfits
+
+import galsim
 from galsim_test_helpers import *
+from galsim._pyfits import pyfits
 
 # Setup info for tests, not likely to change
 ntypes = 8  # Note: Most tests below only run through the first 8 types.
@@ -86,7 +88,9 @@ np_types = [
     np.complex128,
 ]
 tchar = ["S", "I", "US", "UI", "F", "D", "CF", "CD", "I", "D", "CD"]
-int_ntypes = 4  # The first four are the integer types for which we need to test &, |, ^.
+int_ntypes = (
+    4  # The first four are the integer types for which we need to test &, |, ^.
+)
 
 ncol = 7
 nrow = 5
@@ -125,7 +129,7 @@ def test_Image_basic():
         print("array_type = ", array_type, np_array_type)
 
         # Check basic constructor from ncol, nrow
-        im1 = galsim.Image.init(ncol, nrow, dtype=array_type)
+        im1 = galsim.Image(ncol, nrow, dtype=array_type)
 
         # Check basic features of array built by Image
         np.testing.assert_array_equal(im1.array, 0.0)
@@ -150,13 +154,13 @@ def test_Image_basic():
         assert im1.outer_bounds == galsim.BoundsD(0.5, ncol + 0.5, 0.5, nrow + 0.5)
 
         # Same thing if ncol,nrow are kwargs.  Also can give init_value
-        im1b = galsim.Image.init(ncol=ncol, nrow=nrow, dtype=array_type, init_value=23)
+        im1b = galsim.Image(ncol=ncol, nrow=nrow, dtype=array_type, init_value=23)
         np.testing.assert_array_equal(im1b.array, 23.0)
         assert im1 == im1b
 
         # Adding on xmin, ymin allows you to set an origin other than (1,1)
-        im1a = galsim.Image.init(ncol, nrow, dtype=array_type, xmin=4, ymin=7)
-        im1b = galsim.Image.init(ncol=ncol, nrow=nrow, dtype=array_type, xmin=0, ymin=0)
+        im1a = galsim.Image(ncol, nrow, dtype=array_type, xmin=4, ymin=7)
+        im1b = galsim.Image(ncol=ncol, nrow=nrow, dtype=array_type, xmin=0, ymin=0)
         assert im1a.xmin == 4
         assert im1a.xmax == ncol + 3
         assert im1a.ymin == 7
@@ -171,10 +175,12 @@ def test_Image_basic():
         assert im1b.outer_bounds == galsim.BoundsD(-0.5, ncol - 0.5, -0.5, nrow - 0.5)
 
         # Also test alternate name of image type: ImageD, ImageF, etc.
-        image_type = eval("galsim.Image" + tchar[i])  # Use handy eval() mimics use of ImageSIFD
+        image_type = eval(
+            "galsim.Image" + tchar[i]
+        )  # Use handy eval() mimics use of ImageSIFD
         im2 = image_type(bounds, init_value=23)
         im2_view = im2.view()
-        # im2_cview = im2.view(make_const=True) # JAX specific modification
+        im2_cview = im2.view(make_const=True)
         im2_conj = im2.conjugate
 
         assert im2_view.xmin == 1
@@ -185,15 +191,13 @@ def test_Image_basic():
         assert im2_view.array.dtype.type == np_array_type
         assert im2_view.dtype == np_array_type
 
-        # JAX specific modification
-        # -------------------------
-        # assert im2_cview.xmin == 1
-        # assert im2_cview.xmax == ncol
-        # assert im2_cview.ymin == 1
-        # assert im2_cview.ymax == nrow
-        # assert im2_cview.bounds == bounds
-        # assert im2_cview.array.dtype.type == np_array_type
-        # assert im2_cview.dtype == np_array_type
+        assert im2_cview.xmin == 1
+        assert im2_cview.xmax == ncol
+        assert im2_cview.ymin == 1
+        assert im2_cview.ymax == nrow
+        assert im2_cview.bounds == bounds
+        assert im2_cview.array.dtype.type == np_array_type
+        assert im2_cview.dtype == np_array_type
 
         assert im1.real.bounds == bounds
         assert im1.imag.bounds == bounds
@@ -201,10 +205,8 @@ def test_Image_basic():
         assert im2.imag.bounds == bounds
         assert im2_view.real.bounds == bounds
         assert im2_view.imag.bounds == bounds
-        # JAX specific modification
-        # -------------------------
-        # assert im2_cview.real.bounds == bounds
-        # assert im2_cview.imag.bounds == bounds
+        assert im2_cview.real.bounds == bounds
+        assert im2_cview.imag.bounds == bounds
         if tchar[i] == "CF":
             assert im1.real.dtype == np.float32
             assert im1.imag.dtype == np.float32
@@ -232,7 +234,7 @@ def test_Image_basic():
         # And we recreate the view and conjugates from the modified
         # array
         im2_view = im2.view()
-        # im2_cview = im2.view(make_const=True)  # JAX specific modification
+        im2_cview = im2.view(make_const=True)
         im2_conj = im2.conjugate
 
         for y in range(1, nrow + 1):
@@ -244,11 +246,11 @@ def test_Image_basic():
                 assert im1b(x - 1, y - 1) == value
                 assert im1.view()(x, y) == value
                 assert im1.view()(galsim.PositionI(x, y)) == value
-                # assert im1.view(make_const=True)(x, y) == value # JAX specific modification
+                assert im1.view(make_const=True)(x, y) == value
                 assert im2(x, y) == value
                 assert im2_view(x, y) == value
+                assert im2_cview(x, y) == value
                 assert im1.conjugate(x, y) == value
-                # assert im2_cview(x, y) == value # JAX specific modification
                 # JAX specific modification
                 # -------------------------
                 # We have actually redefined im2_conj, so we can use this line
@@ -269,28 +271,26 @@ def test_Image_basic():
                 # -------------------------
                 # Also updating the value of im2 and the cview
                 im2[galsim.PositionI(x, y)] = value2
-                # im2_cview[galsim.PositionI(x, y)] = value2 # JAX specific modification
+                im2_cview[galsim.PositionI(x, y)] = value2
                 assert im1.getValue(x, y) == value2
                 assert im1.view().getValue(x=x, y=y) == value2
-                # JAX specific modification
-                # assert im1.view(make_const=True).getValue(x, y) == value2
-                # assert im2_cview._getValue(x, y) == value2 # JAX specific modification
+                assert im1.view(make_const=True).getValue(x, y) == value2
                 assert im2.getValue(x=x, y=y) == value2
                 assert im2_view.getValue(x, y) == value2
+                assert im2_cview._getValue(x, y) == value2
 
                 assert im1.real(x, y) == value2
                 assert im1.view().real(x, y) == value2
-                # JAX specific modification
-                # assert im1.view(make_const=True).real(x, y) == value2.real
-                # assert im2_cview.real(x, y) == value2.real
-                # assert im1.view(make_const=True).imag(x, y) == 0  # JAX specific modification
-                # assert im2_cview.imag(x, y) == 0
+                assert im1.view(make_const=True).real(x, y) == value2.real
                 assert im2.real(x, y) == value2.real
                 assert im2_view.real(x, y) == value2.real
+                assert im2_cview.real(x, y) == value2.real
                 assert im1.imag(x, y) == 0
                 assert im1.view().imag(x, y) == 0
+                assert im1.view(make_const=True).imag(x, y) == 0
                 assert im2.imag(x, y) == 0
                 assert im2_view.imag(x, y) == 0
+                assert im2_cview.imag(x, y) == 0
 
                 value3 = 10 * x + y
                 im1.addValue(x, y, value3 - value2)
@@ -298,14 +298,14 @@ def test_Image_basic():
                 # JAX specific modification
                 # -------------------------
                 # Also updating the value of im2 and the cview
-                # im2_cview[galsim.PositionI(x, y)] += value3 - value2
-                # assert im1.view(make_const=True)[galsim.PositionI(x, y)] == value3
-                # assert im2_cview[x, y] == value3
                 im2[galsim.PositionI(x, y)] += value3 - value2
+                im2_cview[galsim.PositionI(x, y)] += value3 - value2
                 assert im1[galsim.PositionI(x, y)] == value3
                 assert im1.view()[x, y] == value3
+                assert im1.view(make_const=True)[galsim.PositionI(x, y)] == value3
                 assert im2[x, y] == value3
                 assert im2_view[galsim.PositionI(x, y)] == value3
+                assert im2_cview[x, y] == value3
 
         # Setting or getting the value outside the bounds should throw an exception.
         assert_raises(galsim.GalSimBoundsError, im1.setValue, 0, 0, 1)
@@ -333,11 +333,17 @@ def test_Image_basic():
         assert_raises(galsim.GalSimBoundsError, im1.setValue, ncol + 1, nrow + 1, 1)
         assert_raises(galsim.GalSimBoundsError, im1.addValue, ncol + 1, nrow + 1, 1)
         assert_raises(galsim.GalSimBoundsError, im1.__call__, ncol + 1, nrow + 1)
-        assert_raises(galsim.GalSimBoundsError, im1.view().setValue, ncol + 1, nrow + 1, 1)
+        assert_raises(
+            galsim.GalSimBoundsError, im1.view().setValue, ncol + 1, nrow + 1, 1
+        )
         assert_raises(galsim.GalSimBoundsError, im1.view().__call__, ncol + 1, nrow + 1)
 
-        assert_raises(galsim.GalSimBoundsError, im1.__getitem__, galsim.BoundsI(0, ncol, 1, nrow))
-        assert_raises(galsim.GalSimBoundsError, im1.__getitem__, galsim.BoundsI(1, ncol, 0, nrow))
+        assert_raises(
+            galsim.GalSimBoundsError, im1.__getitem__, galsim.BoundsI(0, ncol, 1, nrow)
+        )
+        assert_raises(
+            galsim.GalSimBoundsError, im1.__getitem__, galsim.BoundsI(1, ncol, 0, nrow)
+        )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.__getitem__,
@@ -353,10 +359,18 @@ def test_Image_basic():
             im1.__getitem__,
             galsim.BoundsI(0, ncol + 1, 0, nrow + 1),
         )
-        assert_raises(galsim.GalSimBoundsError, im1.subImage, galsim.BoundsI(0, ncol, 1, nrow))
-        assert_raises(galsim.GalSimBoundsError, im1.subImage, galsim.BoundsI(1, ncol, 0, nrow))
-        assert_raises(galsim.GalSimBoundsError, im1.subImage, galsim.BoundsI(1, ncol + 1, 1, nrow))
-        assert_raises(galsim.GalSimBoundsError, im1.subImage, galsim.BoundsI(1, ncol, 1, nrow + 1))
+        assert_raises(
+            galsim.GalSimBoundsError, im1.subImage, galsim.BoundsI(0, ncol, 1, nrow)
+        )
+        assert_raises(
+            galsim.GalSimBoundsError, im1.subImage, galsim.BoundsI(1, ncol, 0, nrow)
+        )
+        assert_raises(
+            galsim.GalSimBoundsError, im1.subImage, galsim.BoundsI(1, ncol + 1, 1, nrow)
+        )
+        assert_raises(
+            galsim.GalSimBoundsError, im1.subImage, galsim.BoundsI(1, ncol, 1, nrow + 1)
+        )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.subImage,
@@ -367,61 +381,61 @@ def test_Image_basic():
             galsim.GalSimBoundsError,
             im1.setSubImage,
             galsim.BoundsI(0, ncol, 1, nrow),
-            galsim.Image.init(ncol + 1, nrow, init_value=10),
+            galsim.Image(ncol + 1, nrow, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.setSubImage,
             galsim.BoundsI(1, ncol, 0, nrow),
-            galsim.Image.init(ncol + 1, nrow, init_value=10),
+            galsim.Image(ncol + 1, nrow, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.setSubImage,
             galsim.BoundsI(1, ncol + 1, 1, nrow),
-            galsim.Image.init(ncol + 1, nrow, init_value=10),
+            galsim.Image(ncol + 1, nrow, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.setSubImage,
             galsim.BoundsI(1, ncol, 1, nrow + 1),
-            galsim.Image.init(ncol + 1, nrow, init_value=10),
+            galsim.Image(ncol + 1, nrow, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.setSubImage,
             galsim.BoundsI(0, ncol + 1, 0, nrow + 1),
-            galsim.Image.init(ncol + 2, nrow + 2, init_value=10),
+            galsim.Image(ncol + 2, nrow + 2, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.__setitem__,
             galsim.BoundsI(0, ncol, 1, nrow),
-            galsim.Image.init(ncol + 1, nrow, init_value=10),
+            galsim.Image(ncol + 1, nrow, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.__setitem__,
             galsim.BoundsI(1, ncol, 0, nrow),
-            galsim.Image.init(ncol + 1, nrow, init_value=10),
+            galsim.Image(ncol + 1, nrow, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.__setitem__,
             galsim.BoundsI(1, ncol + 1, 1, nrow),
-            galsim.Image.init(ncol + 1, nrow, init_value=10),
+            galsim.Image(ncol + 1, nrow, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.__setitem__,
             galsim.BoundsI(1, ncol, 1, nrow + 1),
-            galsim.Image.init(ncol + 1, nrow, init_value=10),
+            galsim.Image(ncol + 1, nrow, init_value=10),
         )
         assert_raises(
             galsim.GalSimBoundsError,
             im1.__setitem__,
             galsim.BoundsI(0, ncol + 1, 0, nrow + 1),
-            galsim.Image.init(ncol + 2, nrow + 2, init_value=10),
+            galsim.Image(ncol + 2, nrow + 2, init_value=10),
         )
 
         # JAX specific modification
@@ -441,13 +455,15 @@ def test_Image_basic():
         assert_raises(TypeError, im1.__setitem__, 1, 2, 3, 4)
 
         # Check view of given data
-        im3_view = galsim.Image.init(ref_array.astype(np_array_type))
+        im3_view = galsim.Image(ref_array.astype(np_array_type))
         slice_array = large_array.astype(np_array_type)[::3, ::2]
-        im4_view = galsim.Image.init(slice_array)
-        im5_view = galsim.Image.init(ref_array.astype(np_array_type).tolist(), dtype=array_type)
-        im6_view = galsim.Image.init(ref_array.astype(np_array_type), xmin=4, ymin=7)
-        im7_view = galsim.Image.init(ref_array.astype(np_array_type), xmin=0, ymin=0)
-        im8_view = galsim.Image.init(ref_array).view(dtype=np_array_type)
+        im4_view = galsim.Image(slice_array)
+        im5_view = galsim.Image(
+            ref_array.astype(np_array_type).tolist(), dtype=array_type
+        )
+        im6_view = galsim.Image(ref_array.astype(np_array_type), xmin=4, ymin=7)
+        im7_view = galsim.Image(ref_array.astype(np_array_type), xmin=0, ymin=0)
+        im8_view = galsim.Image(ref_array).view(dtype=np_array_type)
         for y in range(1, nrow + 1):
             for x in range(1, ncol + 1):
                 value3 = 10 * x + y
@@ -464,7 +480,7 @@ def test_Image_basic():
         dy = 16
         im1.shift(dx, dy)
         im2_view.setOrigin(1 + dx, 1 + dy)
-        im3_view.setCenter(int((ncol + 1) / 2 + dx), int((nrow + 1) / 2 + dy))
+        im3_view.setCenter((ncol + 1) / 2 + dx, (nrow + 1) / 2 + dy)
         shifted_bounds = galsim.BoundsI(1 + dx, ncol + dx, 1 + dy, nrow + dy)
 
         assert im1.bounds == shifted_bounds
@@ -515,34 +531,38 @@ def test_Image_basic():
 def test_undefined_image():
     """Test various ways to construct an image with undefined bounds"""
     for i in range(len(types)):
-        im1 = galsim.Image.init(dtype=types[i])
+        im1 = galsim.Image(dtype=types[i])
         assert not im1.bounds.isDefined()
         assert im1.array.shape == (1, 1)
         assert im1 == im1
 
-        im2 = galsim.Image.init()
+        im2 = galsim.Image()
         assert not im2.bounds.isDefined()
         assert im2.array.shape == (1, 1)
         assert im2 == im2
         if types[i] == np.float32:
             assert im2 == im1
 
-        im3 = galsim.Image.init(array=np.array([[]], dtype=types[i]))
+        im3 = galsim.Image(array=np.array([[]], dtype=types[i]))
         assert not im3.bounds.isDefined()
         assert im3.array.shape == (1, 1)
         assert im3 == im1
 
-        im4 = galsim.Image.init(array=np.array([[]]), dtype=types[i])
+        im4 = galsim.Image(array=np.array([[]]), dtype=types[i])
         assert not im4.bounds.isDefined()
         assert im4.array.shape == (1, 1)
         assert im4 == im1
 
-        im5 = galsim.Image.init(array=np.array([[1]]), dtype=types[i], bounds=galsim.BoundsI())
+        im5 = galsim.Image(
+            array=np.array([[1]]), dtype=types[i], bounds=galsim.BoundsI()
+        )
         assert not im5.bounds.isDefined()
         assert im5.array.shape == (1, 1)
         assert im5 == im1
 
-        im6 = galsim.Image.init(array=np.array([[1]], dtype=types[i]), bounds=galsim.BoundsI())
+        im6 = galsim.Image(
+            array=np.array([[1]], dtype=types[i]), bounds=galsim.BoundsI()
+        )
         assert not im6.bounds.isDefined()
         assert im6.array.shape == (1, 1)
         assert im6 == im1
@@ -562,15 +582,15 @@ def test_undefined_image():
         # JAX specific modification
         # -------------------------
         # We don't handle empty images
-        # im9 = galsim.Image.init(0, 0)
+        # im9 = galsim.Image(0, 0)
         # assert im9.array.shape == (1,1)
         # assert im9 == im1
         #
-        # im10 = galsim.Image.init(10, 0)
+        # im10 = galsim.Image(10, 0)
         # assert im10.array.shape == (1,1)
         # assert im10 == im1
         #
-        # im11 = galsim.Image.init(0, 19)
+        # im11 = galsim.Image(0, 19)
         # assert im11.array.shape == (1,1)
         # assert im11 == im1
 
@@ -588,19 +608,21 @@ def test_undefined_image():
             im1.__getitem__,
             galsim.BoundsI(1, 2, 1, 2),
         )
-        assert_raises(galsim.GalSimUndefinedBoundsError, im1.subImage, galsim.BoundsI(1, 2, 1, 2))
+        assert_raises(
+            galsim.GalSimUndefinedBoundsError, im1.subImage, galsim.BoundsI(1, 2, 1, 2)
+        )
 
         assert_raises(
             galsim.GalSimUndefinedBoundsError,
             im1.setSubImage,
             galsim.BoundsI(1, 2, 1, 2),
-            galsim.Image.init(2, 2, init_value=10),
+            galsim.Image(2, 2, init_value=10),
         )
         assert_raises(
             galsim.GalSimUndefinedBoundsError,
             im1.__setitem__,
             galsim.BoundsI(1, 2, 1, 2),
-            galsim.Image.init(2, 2, init_value=10),
+            galsim.Image(2, 2, init_value=10),
         )
 
         im1.scale = 1.0
@@ -626,7 +648,7 @@ def test_Image_FITS_IO():
 
         if tchar[i][0] == "C":
             # Cannot write complex Images to fits.  Check for an exception and continue.
-            ref_image = galsim.Image.init(ref_array.astype(array_type))
+            ref_image = galsim.Image(ref_array.astype(array_type))
             test_file = os.path.join(datadir, "test" + tchar[i] + ".fits")
             with assert_raises(ValueError):
                 ref_image.write(test_file)
@@ -670,7 +692,7 @@ def test_Image_FITS_IO():
         #
 
         # Write the reference image to a fits file
-        ref_image = galsim.Image.init(ref_array.astype(array_type))
+        ref_image = galsim.Image(ref_array.astype(array_type))
         test_file = os.path.join(datadir, "test" + tchar[i] + "_internal.fits")
         ref_image.write(test_file)
 
@@ -916,7 +938,7 @@ def test_Image_MultiFITS_IO():
 
         if tchar[i][0] == "C":
             # Cannot write complex Images to fits.  Check for an exception and continue.
-            ref_image = galsim.Image.init(ref_array.astype(array_type))
+            ref_image = galsim.Image(ref_array.astype(array_type))
             image_list = []
             for k in range(nimages):
                 image_list.append(ref_image + k)
@@ -956,7 +978,9 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readMulti failed reading from filename input.",
+                err_msg="Image"
+                + tchar[i]
+                + " readMulti failed reading from filename input.",
             )
 
         #
@@ -964,13 +988,15 @@ def test_Image_MultiFITS_IO():
         #
 
         # Build a list of images with different values
-        ref_image = galsim.Image.init(ref_array.astype(array_type))
+        ref_image = galsim.Image(ref_array.astype(array_type))
         image_list = []
         for k in range(nimages):
             image_list.append(ref_image + k)
 
         # Write the list to a multi-extension fits file
-        test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + "_internal.fits")
+        test_multi_file = os.path.join(
+            datadir, "test_multi" + tchar[i] + "_internal.fits"
+        )
         galsim.fits.writeMulti(image_list, test_multi_file)
 
         # Check pyfits read for sanity
@@ -999,7 +1025,9 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readMulti failed reading from filename input.",
+                err_msg="Image"
+                + tchar[i]
+                + " readMulti failed reading from filename input.",
             )
 
         #
@@ -1038,7 +1066,9 @@ def test_Image_MultiFITS_IO():
                 err_msg="Image" + tchar[i] + " readMulti failed after using writeFile",
             )
 
-        assert_raises(ValueError, galsim.fits.readMulti, test_multi_file, compression="invalid")
+        assert_raises(
+            ValueError, galsim.fits.readMulti, test_multi_file, compression="invalid"
+        )
         assert_raises(
             ValueError,
             galsim.fits.writeMulti,
@@ -1053,8 +1083,12 @@ def test_Image_MultiFITS_IO():
             test_multi_file,
             compression="invalid",
         )
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file, compression="rice")
-        assert_raises(OSError, galsim.fits.readFile, test_multi_file, compression="rice")
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file, compression="rice"
+        )
+        assert_raises(
+            OSError, galsim.fits.readFile, test_multi_file, compression="rice"
+        )
         assert_raises(OSError, galsim.fits.readMulti, hdu_list=pyfits.HDUList())
         assert_raises(
             OSError,
@@ -1078,7 +1112,9 @@ def test_Image_MultiFITS_IO():
             hdu_list=hdu,
         )
 
-        assert_raises(OSError, galsim.fits.writeMulti, image_list, test_multi_file, clobber=False)
+        assert_raises(
+            OSError, galsim.fits.writeMulti, image_list, test_multi_file, clobber=False
+        )
 
         assert_raises(TypeError, galsim.fits.writeFile)
         assert_raises(TypeError, galsim.fits.writeFile, image_list)
@@ -1119,7 +1155,9 @@ def test_Image_MultiFITS_IO():
         )
 
         galsim.fits.writeFile(test_multi_file, hdu_list)
-        assert_raises(OSError, galsim.fits.writeFile, test_multi_file, image_list, clobber=False)
+        assert_raises(
+            OSError, galsim.fits.writeFile, test_multi_file, image_list, clobber=False
+        )
 
         #
         # Test various compression schemes
@@ -1140,7 +1178,9 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readMulti failed for explicit full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " readMulti failed for explicit full-file gzip",
             )
 
         test_image_list = galsim.fits.readMulti(test_multi_file)
@@ -1148,17 +1188,23 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readMulti failed for auto full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " readMulti failed for auto full-file gzip",
             )
 
-        test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + "_internal.fits.gz")
+        test_multi_file = os.path.join(
+            datadir, "test_multi" + tchar[i] + "_internal.fits.gz"
+        )
         galsim.fits.writeMulti(image_list, test_multi_file, compression="gzip")
         test_image_list = galsim.fits.readMulti(test_multi_file)
         for k in range(nimages):
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeMulti failed for explicit full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " writeMulti failed for explicit full-file gzip",
             )
 
         galsim.fits.writeMulti(image_list, test_multi_file)
@@ -1167,7 +1213,9 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeMulti failed for auto full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " writeMulti failed for auto full-file gzip",
             )
 
         # With compression = None or 'none', astropy automatically figures it out anyway.
@@ -1176,10 +1224,14 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeMulti failed for auto full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " writeMulti failed for auto full-file gzip",
             )
 
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file0, compression="gzip")
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file0, compression="gzip"
+        )
 
         # Test full-file bzip2
         test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + ".fits.bz2")
@@ -1188,7 +1240,9 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readMulti failed for explicit full-file bzip2",
+                err_msg="Image"
+                + tchar[i]
+                + " readMulti failed for explicit full-file bzip2",
             )
 
         test_image_list = galsim.fits.readMulti(test_multi_file)
@@ -1196,17 +1250,23 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readMulti failed for auto full-file bzip2",
+                err_msg="Image"
+                + tchar[i]
+                + " readMulti failed for auto full-file bzip2",
             )
 
-        test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + "_internal.fits.bz2")
+        test_multi_file = os.path.join(
+            datadir, "test_multi" + tchar[i] + "_internal.fits.bz2"
+        )
         galsim.fits.writeMulti(image_list, test_multi_file, compression="bzip2")
         test_image_list = galsim.fits.readMulti(test_multi_file)
         for k in range(nimages):
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeMulti failed for explicit full-file bzip2",
+                err_msg="Image"
+                + tchar[i]
+                + " writeMulti failed for explicit full-file bzip2",
             )
 
         galsim.fits.writeMulti(image_list, test_multi_file)
@@ -1215,7 +1275,9 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeMulti failed for auto full-file bzip2",
+                err_msg="Image"
+                + tchar[i]
+                + " writeMulti failed for auto full-file bzip2",
             )
 
         # With compression = None or 'none', astropy automatically figures it out anyway.
@@ -1224,10 +1286,14 @@ def test_Image_MultiFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeMulti failed for auto full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " writeMulti failed for auto full-file gzip",
             )
 
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file0, compression="bzip2")
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file0, compression="bzip2"
+        )
 
         # Test rice
         test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + ".fits.fz")
@@ -1247,7 +1313,9 @@ def test_Image_MultiFITS_IO():
                 err_msg="Image" + tchar[i] + " readMulti failed for auto rice",
             )
 
-        test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + "_internal.fits.fz")
+        test_multi_file = os.path.join(
+            datadir, "test_multi" + tchar[i] + "_internal.fits.fz"
+        )
         galsim.fits.writeMulti(image_list, test_multi_file, compression="rice")
         test_image_list = galsim.fits.readMulti(test_multi_file)
         for k in range(nimages):
@@ -1266,13 +1334,21 @@ def test_Image_MultiFITS_IO():
                 err_msg="Image" + tchar[i] + " writeMulti failed for auto rice",
             )
 
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file0, compression="rice")
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file, compression="none")
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file0, compression="rice"
+        )
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file, compression="none"
+        )
 
         # Test gzip_tile
-        test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + "_internal.fits.gzt")
+        test_multi_file = os.path.join(
+            datadir, "test_multi" + tchar[i] + "_internal.fits.gzt"
+        )
         galsim.fits.writeMulti(image_list, test_multi_file, compression="gzip_tile")
-        test_image_list = galsim.fits.readMulti(test_multi_file, compression="gzip_tile")
+        test_image_list = galsim.fits.readMulti(
+            test_multi_file, compression="gzip_tile"
+        )
         for k in range(nimages):
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
@@ -1280,13 +1356,21 @@ def test_Image_MultiFITS_IO():
                 err_msg="Image" + tchar[i] + " writeMulti failed for gzip_tile",
             )
 
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file0, compression="gzip_tile")
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file, compression="none")
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file0, compression="gzip_tile"
+        )
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file, compression="none"
+        )
 
         # Test hcompress
-        test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + "_internal.fits.hc")
+        test_multi_file = os.path.join(
+            datadir, "test_multi" + tchar[i] + "_internal.fits.hc"
+        )
         galsim.fits.writeMulti(image_list, test_multi_file, compression="hcompress")
-        test_image_list = galsim.fits.readMulti(test_multi_file, compression="hcompress")
+        test_image_list = galsim.fits.readMulti(
+            test_multi_file, compression="hcompress"
+        )
         for k in range(nimages):
             np.testing.assert_allclose(
                 (ref_array + k).astype(types[i]),
@@ -1295,12 +1379,18 @@ def test_Image_MultiFITS_IO():
                 err_msg="Image" + tchar[i] + " writeMulti failed for hcompress",
             )
 
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file0, compression="hcompress")
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file, compression="none")
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file0, compression="hcompress"
+        )
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file, compression="none"
+        )
 
         # Test plio (only valid on positive integer values)
         if tchar[i] in ["S", "I"]:
-            test_multi_file = os.path.join(datadir, "test_multi" + tchar[i] + "_internal.fits.plio")
+            test_multi_file = os.path.join(
+                datadir, "test_multi" + tchar[i] + "_internal.fits.plio"
+            )
             galsim.fits.writeMulti(image_list, test_multi_file, compression="plio")
             test_image_list = galsim.fits.readMulti(test_multi_file, compression="plio")
             for k in range(nimages):
@@ -1310,8 +1400,12 @@ def test_Image_MultiFITS_IO():
                     err_msg="Image" + tchar[i] + " writeMulti failed for plio",
                 )
 
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file0, compression="plio")
-        assert_raises(OSError, galsim.fits.readMulti, test_multi_file, compression="none")
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file0, compression="plio"
+        )
+        assert_raises(
+            OSError, galsim.fits.readMulti, test_multi_file, compression="none"
+        )
 
     # Check a file with no WCS information
     nowcs_file = "fits_files/blankimg.fits"
@@ -1334,7 +1428,7 @@ def test_Image_CubeFITS_IO():
 
         if tchar[i][0] == "C":
             # Cannot write complex Images to fits.  Check for an exception and continue.
-            ref_image = galsim.Image.init(ref_array.astype(array_type))
+            ref_image = galsim.Image(ref_array.astype(array_type))
             image_list = []
             for k in range(nimages):
                 image_list.append(ref_image + k)
@@ -1381,7 +1475,9 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readCube failed reading from filename input.",
+                err_msg="Image"
+                + tchar[i]
+                + " readCube failed reading from filename input.",
             )
 
         #
@@ -1389,13 +1485,15 @@ def test_Image_CubeFITS_IO():
         #
 
         # Build a list of images with different values
-        ref_image = galsim.Image.init(ref_array.astype(array_type))
+        ref_image = galsim.Image(ref_array.astype(array_type))
         image_list = []
         for k in range(nimages):
             image_list.append(ref_image + k)
 
         # Write the list to a fits data cube
-        test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + "_internal.fits")
+        test_cube_file = os.path.join(
+            datadir, "test_cube" + tchar[i] + "_internal.fits"
+        )
         galsim.fits.writeCube(image_list, test_cube_file)
 
         # Check pyfits read for sanity
@@ -1429,7 +1527,9 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readCube failed reading from filename input.",
+                err_msg="Image"
+                + tchar[i]
+                + " readCube failed reading from filename input.",
             )
 
         #
@@ -1443,7 +1543,9 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " write/readCube failed with list of numpy arrays.",
+                err_msg="Image"
+                + tchar[i]
+                + " write/readCube failed with list of numpy arrays.",
             )
 
         one_array = np.asarray(array_list)
@@ -1453,7 +1555,9 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " write/readCube failed with single 3D numpy array.",
+                err_msg="Image"
+                + tchar[i]
+                + " write/readCube failed with single 3D numpy array.",
             )
 
         #
@@ -1478,7 +1582,9 @@ def test_Image_CubeFITS_IO():
                 err_msg="Image" + tchar[i] + " readCube failed after using writeFile",
             )
 
-        assert_raises(ValueError, galsim.fits.readCube, test_cube_file, compression="invalid")
+        assert_raises(
+            ValueError, galsim.fits.readCube, test_cube_file, compression="invalid"
+        )
         assert_raises(
             ValueError,
             galsim.fits.writeCube,
@@ -1509,7 +1615,9 @@ def test_Image_CubeFITS_IO():
             hdu_list=hdu_list,
         )
 
-        assert_raises(OSError, galsim.fits.writeCube, image_list, test_cube_file, clobber=False)
+        assert_raises(
+            OSError, galsim.fits.writeCube, image_list, test_cube_file, clobber=False
+        )
 
         assert_raises(ValueError, galsim.fits.writeCube, image_list[:0], test_cube_file)
         assert_raises(
@@ -1538,7 +1646,9 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readCube failed for explicit full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " readCube failed for explicit full-file gzip",
             )
 
         test_image_list = galsim.fits.readCube(test_cube_file)
@@ -1549,14 +1659,18 @@ def test_Image_CubeFITS_IO():
                 err_msg="Image" + tchar[i] + " readCube failed for auto full-file gzip",
             )
 
-        test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + "_internal.fits.gz")
+        test_cube_file = os.path.join(
+            datadir, "test_cube" + tchar[i] + "_internal.fits.gz"
+        )
         galsim.fits.writeCube(image_list, test_cube_file, compression="gzip")
         test_image_list = galsim.fits.readCube(test_cube_file)
         for k in range(nimages):
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeCube failed for explicit full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " writeCube failed for explicit full-file gzip",
             )
 
         galsim.fits.writeCube(image_list, test_cube_file)
@@ -1565,7 +1679,9 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeCube failed for auto full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " writeCube failed for auto full-file gzip",
             )
 
         # With compression = None or 'none', astropy automatically figures it out anyway.
@@ -1574,10 +1690,14 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeCube failed for auto full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " writeCube failed for auto full-file gzip",
             )
 
-        assert_raises(OSError, galsim.fits.readCube, test_cube_file0, compression="gzip")
+        assert_raises(
+            OSError, galsim.fits.readCube, test_cube_file0, compression="gzip"
+        )
 
         # Test full-file bzip2
         test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + ".fits.bz2")
@@ -1586,7 +1706,9 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readCube failed for explicit full-file bzip2",
+                err_msg="Image"
+                + tchar[i]
+                + " readCube failed for explicit full-file bzip2",
             )
 
         test_image_list = galsim.fits.readCube(test_cube_file)
@@ -1594,17 +1716,23 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " readCube failed for auto full-file bzip2",
+                err_msg="Image"
+                + tchar[i]
+                + " readCube failed for auto full-file bzip2",
             )
 
-        test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + "_internal.fits.bz2")
+        test_cube_file = os.path.join(
+            datadir, "test_cube" + tchar[i] + "_internal.fits.bz2"
+        )
         galsim.fits.writeCube(image_list, test_cube_file, compression="bzip2")
         test_image_list = galsim.fits.readCube(test_cube_file)
         for k in range(nimages):
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeCube failed for explicit full-file bzip2",
+                err_msg="Image"
+                + tchar[i]
+                + " writeCube failed for explicit full-file bzip2",
             )
 
         galsim.fits.writeCube(image_list, test_cube_file)
@@ -1613,7 +1741,9 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeCube failed for auto full-file bzip2",
+                err_msg="Image"
+                + tchar[i]
+                + " writeCube failed for auto full-file bzip2",
             )
 
         # With compression = None or 'none', astropy automatically figures it out anyway.
@@ -1622,10 +1752,14 @@ def test_Image_CubeFITS_IO():
             np.testing.assert_array_equal(
                 (ref_array + k).astype(types[i]),
                 test_image_list[k].array,
-                err_msg="Image" + tchar[i] + " writeCube failed for auto full-file gzip",
+                err_msg="Image"
+                + tchar[i]
+                + " writeCube failed for auto full-file gzip",
             )
 
-        assert_raises(OSError, galsim.fits.readCube, test_cube_file0, compression="bzip2")
+        assert_raises(
+            OSError, galsim.fits.readCube, test_cube_file0, compression="bzip2"
+        )
 
         # Test rice
         test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + ".fits.fz")
@@ -1645,7 +1779,9 @@ def test_Image_CubeFITS_IO():
                 err_msg="Image" + tchar[i] + " readCube failed for auto rice",
             )
 
-        test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + "_internal.fits.fz")
+        test_cube_file = os.path.join(
+            datadir, "test_cube" + tchar[i] + "_internal.fits.fz"
+        )
         galsim.fits.writeCube(image_list, test_cube_file, compression="rice")
         test_image_list = galsim.fits.readCube(test_cube_file)
         for k in range(nimages):
@@ -1664,11 +1800,15 @@ def test_Image_CubeFITS_IO():
                 err_msg="Image" + tchar[i] + " writeCube failed for auto rice",
             )
 
-        assert_raises(OSError, galsim.fits.readCube, test_cube_file0, compression="rice")
+        assert_raises(
+            OSError, galsim.fits.readCube, test_cube_file0, compression="rice"
+        )
         assert_raises(OSError, galsim.fits.readCube, test_cube_file, compression="none")
 
         # Test gzip_tile
-        test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + "_internal.fits.gzt")
+        test_cube_file = os.path.join(
+            datadir, "test_cube" + tchar[i] + "_internal.fits.gzt"
+        )
         galsim.fits.writeCube(image_list, test_cube_file, compression="gzip_tile")
         test_image_list = galsim.fits.readCube(test_cube_file, compression="gzip_tile")
         for k in range(nimages):
@@ -1678,11 +1818,15 @@ def test_Image_CubeFITS_IO():
                 err_msg="Image" + tchar[i] + " writeCube failed for gzip_tile",
             )
 
-        assert_raises(OSError, galsim.fits.readCube, test_cube_file0, compression="gzip_tile")
+        assert_raises(
+            OSError, galsim.fits.readCube, test_cube_file0, compression="gzip_tile"
+        )
         assert_raises(OSError, galsim.fits.readCube, test_cube_file, compression="none")
 
         # Test hcompress
-        test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + "_internal.fits.hc")
+        test_cube_file = os.path.join(
+            datadir, "test_cube" + tchar[i] + "_internal.fits.hc"
+        )
         galsim.fits.writeCube(image_list, test_cube_file, compression="hcompress")
         test_image_list = galsim.fits.readCube(test_cube_file, compression="hcompress")
         for k in range(nimages):
@@ -1693,12 +1837,16 @@ def test_Image_CubeFITS_IO():
                 err_msg="Image" + tchar[i] + " writeCube failed for hcompress",
             )
 
-        assert_raises(OSError, galsim.fits.readCube, test_cube_file0, compression="hcompress")
+        assert_raises(
+            OSError, galsim.fits.readCube, test_cube_file0, compression="hcompress"
+        )
         assert_raises(OSError, galsim.fits.readCube, test_cube_file, compression="none")
 
         # Test plio (only valid on positive integer values)
         if tchar[i] in ["S", "I"]:
-            test_cube_file = os.path.join(datadir, "test_cube" + tchar[i] + "_internal.fits.plio")
+            test_cube_file = os.path.join(
+                datadir, "test_cube" + tchar[i] + "_internal.fits.plio"
+            )
             galsim.fits.writeCube(image_list, test_cube_file, compression="plio")
             test_image_list = galsim.fits.readCube(test_cube_file, compression="plio")
             for k in range(nimages):
@@ -1708,7 +1856,9 @@ def test_Image_CubeFITS_IO():
                     err_msg="Image" + tchar[i] + " writeCube failed for plio",
                 )
 
-        assert_raises(OSError, galsim.fits.readCube, test_cube_file0, compression="plio")
+        assert_raises(
+            OSError, galsim.fits.readCube, test_cube_file0, compression="plio"
+        )
         assert_raises(OSError, galsim.fits.readCube, test_cube_file, compression="none")
 
     # Check a file with no WCS information
@@ -1727,11 +1877,12 @@ def test_Image_array_view():
     """Test that all six types of supported Images correctly provide a view on an input array."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image = galsim.Image.init(ref_array.astype(types[i]))
+        image = galsim.Image(ref_array.astype(types[i]))
         np.testing.assert_array_equal(
             ref_array.astype(types[i]),
             image.array,
-            err_msg="Array look into Image class does not match input for dtype = " + str(types[i]),
+            err_msg="Array look into Image class does not match input for dtype = "
+            + str(types[i]),
         )
 
         # Then try using the eval command to mimic use via ImageD, ImageF etc.
@@ -1740,7 +1891,8 @@ def test_Image_array_view():
         np.testing.assert_array_equal(
             ref_array.astype(types[i]),
             image.array,
-            err_msg="Array look into Image class does not match input for dtype = " + str(types[i]),
+            err_msg="Array look into Image class does not match input for dtype = "
+            + str(types[i]),
         )
 
 
@@ -1749,8 +1901,8 @@ def test_Image_binary_add():
     """Test that all six types of supported Images add correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
-        image2 = galsim.Image.init((2 * ref_array).astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image2 = galsim.Image((2 * ref_array).astype(types[i]))
         image3 = image1 + image2
         np.testing.assert_array_equal(
             (3 * ref_array).astype(types[i]),
@@ -1799,8 +1951,8 @@ def test_Image_binary_subtract():
     """Test that all six types of supported Images subtract correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
-        image2 = galsim.Image.init((2 * ref_array).astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image2 = galsim.Image((2 * ref_array).astype(types[i]))
         image3 = image2 - image1
         np.testing.assert_array_equal(
             ref_array.astype(types[i]),
@@ -1846,8 +1998,8 @@ def test_Image_binary_multiply():
     """Test that all six types of supported Images multiply correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
-        image2 = galsim.Image.init((2 * ref_array).astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image2 = galsim.Image((2 * ref_array).astype(types[i]))
         image3 = image1 * image2
         np.testing.assert_array_equal(
             (2 * ref_array**2).astype(types[i]),
@@ -1871,7 +2023,7 @@ def test_Image_binary_multiply():
         )
 
         # Check unary -
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
         image3 = -image1
         np.testing.assert_array_equal(
             image3.array,
@@ -1913,8 +2065,8 @@ def test_Image_binary_divide():
         decimal = 4 if (types[i] == np.complex64 or types[i] == np.float32) else 12
         # First try using the dictionary-type Image init
         # Note that I am using refarray + 1 to avoid divide-by-zero.
-        image1 = galsim.Image.init((ref_array + 1).astype(types[i]))
-        image2 = galsim.Image.init((3 * (ref_array + 1) ** 2).astype(types[i]))
+        image1 = galsim.Image((ref_array + 1).astype(types[i]))
+        image2 = galsim.Image((3 * (ref_array + 1) ** 2).astype(types[i]))
         image3 = image2 / image1
         np.testing.assert_almost_equal(
             (3 * (ref_array + 1)).astype(types[i]),
@@ -1976,7 +2128,7 @@ def test_Image_binary_scalar_add():
     """Test that all six types of supported Images add scalars correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
         image2 = image1 + 3
         np.testing.assert_array_equal(
             (ref_array + 3).astype(types[i]),
@@ -2018,7 +2170,7 @@ def test_Image_binary_scalar_subtract():
     """Test that all six types of supported Images binary scalar subtract correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
         image2 = image1 - 3
         np.testing.assert_array_equal(
             (ref_array - 3).astype(types[i]),
@@ -2060,7 +2212,7 @@ def test_Image_binary_scalar_multiply():
     """Test that all six types of supported Images binary scalar multiply correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
         image2 = image1 * 3
         np.testing.assert_array_equal(
             (ref_array * 3).astype(types[i]),
@@ -2104,7 +2256,7 @@ def test_Image_binary_scalar_divide():
     """Test that all six types of supported Images binary scalar divide correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init((3 * ref_array).astype(types[i]))
+        image1 = galsim.Image((3 * ref_array).astype(types[i]))
         image2 = image1 / 3
         np.testing.assert_array_equal(
             ref_array.astype(types[i]),
@@ -2132,8 +2284,8 @@ def test_Image_binary_scalar_pow():
     """Test that all six types of supported Images can be raised to a power (scalar) correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
-        image2 = galsim.Image.init((ref_array**2).astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image2 = galsim.Image((ref_array**2).astype(types[i]))
         image3 = image1**2
         # Note: unlike for the tests above with multiplication, the test fails if I use
         # assert_array_equal.  I have to use assert_array_almost_equal to avoid failure due to
@@ -2187,8 +2339,8 @@ def test_Image_inplace_add():
     """Test that all six types of supported Images inplace add correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
-        image2 = galsim.Image.init((2 * ref_array).astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image2 = galsim.Image((2 * ref_array).astype(types[i]))
         image1 += image2
         np.testing.assert_array_equal(
             (3 * ref_array).astype(types[i]),
@@ -2235,8 +2387,8 @@ def test_Image_inplace_subtract():
     """Test that all six types of supported Images inplace subtract correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init((2 * ref_array).astype(types[i]))
-        image2 = galsim.Image.init(ref_array.astype(types[i]))
+        image1 = galsim.Image((2 * ref_array).astype(types[i]))
+        image2 = galsim.Image(ref_array.astype(types[i]))
         image1 -= image2
         np.testing.assert_array_equal(
             ref_array.astype(types[i]),
@@ -2284,8 +2436,8 @@ def test_Image_inplace_multiply():
     """Test that all six types of supported Images inplace multiply correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
-        image2 = galsim.Image.init((2 * ref_array).astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image2 = galsim.Image((2 * ref_array).astype(types[i]))
         image1 *= image2
         np.testing.assert_array_equal(
             (2 * ref_array**2).astype(types[i]),
@@ -2336,8 +2488,8 @@ def test_Image_inplace_divide():
         # Decimals adjusted for float32 because computation on gpu is different than cpu
         decimal = 5 if (types[i] == np.complex64 or types[i] == np.float32) else 12
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init((2 * (ref_array + 1) ** 2).astype(types[i]))
-        image2 = galsim.Image.init((ref_array + 1).astype(types[i]))
+        image1 = galsim.Image((2 * (ref_array + 1) ** 2).astype(types[i]))
+        image2 = galsim.Image((ref_array + 1).astype(types[i]))
         image1 /= image2
         np.testing.assert_almost_equal(
             (2 * (ref_array + 1)).astype(types[i]),
@@ -2364,7 +2516,7 @@ def test_Image_inplace_divide():
 
         # Test image.invertSelf()
         # Intentionally make some elements zero, so we test that 1/0 -> 0.
-        image1 = galsim.Image.init((ref_array // 11 - 3).astype(types[i]))
+        image1 = galsim.Image((ref_array // 11 - 3).astype(types[i]))
         image2 = image1.copy()
         mask1 = image1.array == 0
         mask2 = image1.array != 0
@@ -2416,7 +2568,7 @@ def test_Image_inplace_scalar_add():
     """Test that all six types of supported Images inplace scalar add correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
         image1 += 1
         np.testing.assert_array_equal(
             (ref_array + 1).astype(types[i]),
@@ -2443,7 +2595,7 @@ def test_Image_inplace_scalar_subtract():
     """Test that all six types of supported Images inplace scalar subtract correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
         image1 -= 1
         np.testing.assert_array_equal(
             (ref_array - 1).astype(types[i]),
@@ -2471,8 +2623,8 @@ def test_Image_inplace_scalar_multiply():
     """Test that all six types of supported Images inplace scalar multiply correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
-        image2 = galsim.Image.init((2 * ref_array).astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image2 = galsim.Image((2 * ref_array).astype(types[i]))
         image1 *= 2
         np.testing.assert_array_equal(
             image1.array,
@@ -2501,8 +2653,8 @@ def test_Image_inplace_scalar_divide():
     """Test that all six types of supported Images inplace scalar divide correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init(ref_array.astype(types[i]))
-        image2 = galsim.Image.init((2 * ref_array).astype(types[i]))
+        image1 = galsim.Image(ref_array.astype(types[i]))
+        image2 = galsim.Image((2 * ref_array).astype(types[i]))
         image2 /= 2
         np.testing.assert_array_equal(
             image1.array,
@@ -2530,8 +2682,8 @@ def test_Image_inplace_scalar_pow():
     """Test that all six types of supported Images can be raised (in-place) to a scalar correctly."""
     for i in range(ntypes):
         # First try using the dictionary-type Image init
-        image1 = galsim.Image.init((ref_array**2).astype(types[i]))
-        image2 = galsim.Image.init(ref_array.astype(types[i]))
+        image1 = galsim.Image((ref_array**2).astype(types[i]))
+        image2 = galsim.Image(ref_array.astype(types[i]))
         image2 **= 2
         np.testing.assert_array_almost_equal(
             image1.array,
@@ -2559,8 +2711,8 @@ def test_Image_inplace_scalar_pow():
         # float types can also be taken to a float power
         if types[i] in [np.float32, np.float64]:
             # First try using the dictionary-type Image init
-            image1 = galsim.Image.init(ref_array.astype(types[i]))
-            image2 = galsim.Image.init((ref_array ** (1.0 / 1.3)).astype(types[i]))
+            image1 = galsim.Image(ref_array.astype(types[i]))
+            image2 = galsim.Image((ref_array ** (1.0 / 1.3)).astype(types[i]))
             image2 **= 1.3
             np.testing.assert_array_almost_equal(
                 image1.array,
@@ -2579,24 +2731,27 @@ def test_Image_inplace_scalar_pow():
 def test_Image_subImage():
     """Test that subImages are accessed and written correctly."""
     for i in range(ntypes):
-        image = galsim.Image.init(ref_array.astype(types[i]))
+        image = galsim.Image(ref_array.astype(types[i]))
         bounds = galsim.BoundsI(3, 4, 2, 3)
         sub_array = np.array([[32, 42], [33, 43]]).astype(types[i])
         np.testing.assert_array_equal(
             image.subImage(bounds).array,
             sub_array,
-            err_msg="image.subImage(bounds) does not match reference for dtype = " + str(types[i]),
+            err_msg="image.subImage(bounds) does not match reference for dtype = "
+            + str(types[i]),
         )
         np.testing.assert_array_equal(
             image[bounds].array,
             sub_array,
-            err_msg="image[bounds] does not match reference for dtype = " + str(types[i]),
+            err_msg="image[bounds] does not match reference for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init(sub_array + 100)
+        image[bounds] = galsim.Image(sub_array + 100)
         np.testing.assert_array_equal(
             image[bounds].array,
             (sub_array + 100),
-            err_msg="image[bounds] = im2 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] = im2 does not set correctly for dtype = "
+            + str(types[i]),
         )
         for xpos in range(1, test_shape[0] + 1):
             for ypos in range(1, test_shape[1] + 1):
@@ -2611,119 +2766,137 @@ def test_Image_subImage():
                     value = ref_array[ypos - 1, xpos - 1]
                 assert (
                     image(xpos, ypos) == value
-                ), "image[bounds] = im2 set wrong locations for dtype = " + str(types[i])
+                ), "image[bounds] = im2 set wrong locations for dtype = " + str(
+                    types[i]
+                )
 
-        image = galsim.Image.init(ref_array.astype(types[i]))
+        image = galsim.Image(ref_array.astype(types[i]))
         image[bounds] += 100
         np.testing.assert_array_equal(
             image[bounds].array,
             (sub_array + 100),
-            err_msg="image[bounds] += 100 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] += 100 does not set correctly for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init(sub_array)
+        image[bounds] = galsim.Image(sub_array)
         np.testing.assert_array_equal(
             image.array,
             ref_array,
-            err_msg="image[bounds] += 100 set wrong locations for dtype = " + str(types[i]),
+            err_msg="image[bounds] += 100 set wrong locations for dtype = "
+            + str(types[i]),
         )
 
-        image = galsim.Image.init(ref_array.astype(types[i]))
+        image = galsim.Image(ref_array.astype(types[i]))
         image[bounds] -= 100
         np.testing.assert_array_equal(
             image[bounds].array,
             (sub_array - 100),
-            err_msg="image[bounds] -= 100 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] -= 100 does not set correctly for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init(sub_array)
+        image[bounds] = galsim.Image(sub_array)
         np.testing.assert_array_equal(
             image.array,
             ref_array,
-            err_msg="image[bounds] -= 100 set wrong locations for dtype = " + str(types[i]),
+            err_msg="image[bounds] -= 100 set wrong locations for dtype = "
+            + str(types[i]),
         )
 
-        image = galsim.Image.init(ref_array.astype(types[i]))
+        image = galsim.Image(ref_array.astype(types[i]))
         image[bounds] *= 100
         np.testing.assert_array_equal(
             image[bounds].array,
             (sub_array * 100),
-            err_msg="image[bounds] *= 100 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] *= 100 does not set correctly for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init(sub_array)
+        image[bounds] = galsim.Image(sub_array)
         np.testing.assert_array_equal(
             image.array,
             ref_array,
-            err_msg="image[bounds] *= 100 set wrong locations for dtype = " + str(types[i]),
+            err_msg="image[bounds] *= 100 set wrong locations for dtype = "
+            + str(types[i]),
         )
 
-        image = galsim.Image.init((100 * ref_array).astype(types[i]))
+        image = galsim.Image((100 * ref_array).astype(types[i]))
         image[bounds] /= 100
         np.testing.assert_array_equal(
             image[bounds].array,
             (sub_array),
-            err_msg="image[bounds] /= 100 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] /= 100 does not set correctly for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init((100 * sub_array).astype(types[i]))
+        image[bounds] = galsim.Image((100 * sub_array).astype(types[i]))
         np.testing.assert_array_equal(
             image.array,
             (100 * ref_array),
-            err_msg="image[bounds] /= 100 set wrong locations for dtype = " + str(types[i]),
+            err_msg="image[bounds] /= 100 set wrong locations for dtype = "
+            + str(types[i]),
         )
 
-        im2 = galsim.Image.init(sub_array)
-        image = galsim.Image.init(ref_array.astype(types[i]))
+        im2 = galsim.Image(sub_array)
+        image = galsim.Image(ref_array.astype(types[i]))
         image[bounds] += im2
         np.testing.assert_array_equal(
             image[bounds].array,
             (2 * sub_array),
-            err_msg="image[bounds] += im2 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] += im2 does not set correctly for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init(sub_array)
+        image[bounds] = galsim.Image(sub_array)
         np.testing.assert_array_equal(
             image.array,
             ref_array,
-            err_msg="image[bounds] += im2 set wrong locations for dtype = " + str(types[i]),
+            err_msg="image[bounds] += im2 set wrong locations for dtype = "
+            + str(types[i]),
         )
 
-        image = galsim.Image.init(2 * ref_array.astype(types[i]))
+        image = galsim.Image(2 * ref_array.astype(types[i]))
         image[bounds] -= im2
         np.testing.assert_array_equal(
             image[bounds].array,
             sub_array,
-            err_msg="image[bounds] -= im2 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] -= im2 does not set correctly for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init((2 * sub_array).astype(types[i]))
+        image[bounds] = galsim.Image((2 * sub_array).astype(types[i]))
         np.testing.assert_array_equal(
             image.array,
             (2 * ref_array),
-            err_msg="image[bounds] -= im2 set wrong locations for dtype = " + str(types[i]),
+            err_msg="image[bounds] -= im2 set wrong locations for dtype = "
+            + str(types[i]),
         )
 
-        image = galsim.Image.init(ref_array.astype(types[i]))
+        image = galsim.Image(ref_array.astype(types[i]))
         image[bounds] *= im2
         np.testing.assert_array_equal(
             image[bounds].array,
             (sub_array**2),
-            err_msg="image[bounds] *= im2 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] *= im2 does not set correctly for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init(sub_array)
+        image[bounds] = galsim.Image(sub_array)
         np.testing.assert_array_equal(
             image.array,
             ref_array,
-            err_msg="image[bounds] *= im2 set wrong locations for dtype = " + str(types[i]),
+            err_msg="image[bounds] *= im2 set wrong locations for dtype = "
+            + str(types[i]),
         )
 
-        image = galsim.Image.init((2 * ref_array**2).astype(types[i]))
+        image = galsim.Image((2 * ref_array**2).astype(types[i]))
         image[bounds] /= im2
         np.testing.assert_array_equal(
             image[bounds].array,
             (2 * sub_array),
-            err_msg="image[bounds] /= im2 does not set correctly for dtype = " + str(types[i]),
+            err_msg="image[bounds] /= im2 does not set correctly for dtype = "
+            + str(types[i]),
         )
-        image[bounds] = galsim.Image.init((2 * sub_array**2).astype(types[i]))
+        image[bounds] = galsim.Image((2 * sub_array**2).astype(types[i]))
         np.testing.assert_array_equal(
             image.array,
             (2 * ref_array**2),
-            err_msg="image[bounds] /= im2 set wrong locations for dtype = " + str(types[i]),
+            err_msg="image[bounds] /= im2 set wrong locations for dtype = "
+            + str(types[i]),
         )
 
         # JAX specific modification
@@ -2773,13 +2946,13 @@ def test_Image_resize():
         for shape in [(10, 10), (3, 20), (21, 8), (1, 3), (13, 30)]:
             # im1 starts with basic constructor with a given size
             array_type = types[i]
-            im1 = galsim.Image.init(5, 5, dtype=array_type, scale=0.1)
+            im1 = galsim.Image(5, 5, dtype=array_type, scale=0.1)
 
             # im2 stars with null constructor
-            im2 = galsim.Image.init(dtype=array_type, scale=0.2)
+            im2 = galsim.Image(dtype=array_type, scale=0.2)
 
             # im3 is a view into a larger image
-            im3_full = galsim.Image.init(10, 10, dtype=array_type, init_value=23, scale=0.3)
+            im3_full = galsim.Image(10, 10, dtype=array_type, init_value=23, scale=0.3)
             im3 = im3_full.subImage(galsim.BoundsI(1, 6, 1, 6))
 
             # Make sure at least one of the _arrays is instantiated.  This isn't required,
@@ -2850,7 +3023,9 @@ def test_Image_resize():
             )
 
             # Also, since the view was resized, it should no longer be coupled to the original.
-            np.testing.assert_array_equal(im3_full.array, 23, err_msg="im3_full changed")
+            np.testing.assert_array_equal(
+                im3_full.array, 23, err_msg="im3_full changed"
+            )
 
             do_pickle(im1)
             do_pickle(im2)
@@ -2956,7 +3131,7 @@ def test_Image_constructor():
         test_arr[1, 3] = -5
         test_arr[2, 2] = 7
         # Initialize the Image from it.
-        test_im = galsim.Image.init(test_arr)
+        test_im = galsim.Image(test_arr)
         # Check that the image.array attribute matches the original.
         np.testing.assert_array_equal(
             test_arr,
@@ -2970,7 +3145,7 @@ def test_Image_constructor():
         test_arr[1, 3] = -5
         test_arr[2, 2] = 7
         # Initialize the Image from it.
-        test_im = galsim.Image.init(test_arr)
+        test_im = galsim.Image(test_arr)
         # Check that the image.array attribute matches the original.
         np.testing.assert_array_equal(
             test_arr,
@@ -2985,58 +3160,64 @@ def test_Image_constructor():
 
         # Check that some invalid sets of construction args raise the appropriate errors
         # Invalid args
-        assert_raises(TypeError, galsim.Image.init, 1, 2, 3)
-        assert_raises(TypeError, galsim.Image.init, 128)
-        assert_raises(TypeError, galsim.Image.init, 1.8)
-        assert_raises(TypeError, galsim.Image.init, 1.3, 2.7)
+        assert_raises(TypeError, galsim.Image, 1, 2, 3)
+        assert_raises(TypeError, galsim.Image, 128)
+        assert_raises(TypeError, galsim.Image, 1.8)
+        assert_raises(TypeError, galsim.Image, 1.3, 2.7)
         # Invalid array kwarg
-        assert_raises(TypeError, galsim.Image.init, array=5)
-        assert_raises(TypeError, galsim.Image.init, array=test_im)
+        assert_raises(TypeError, galsim.Image, array=5)
+        assert_raises(TypeError, galsim.Image, array=test_im)
         # Invalid image kwarg
-        assert_raises(TypeError, galsim.Image.init, image=5)
-        assert_raises(TypeError, galsim.Image.init, image=test_arr)
+        assert_raises(TypeError, galsim.Image, image=5)
+        assert_raises(TypeError, galsim.Image, image=test_arr)
         # Invalid bounds
-        assert_raises(TypeError, galsim.Image.init, bounds=(1, 4, 1, 3))
-        assert_raises(TypeError, galsim.Image.init, bounds=galsim.BoundsD(1, 4, 1, 3))
-        assert_raises(TypeError, galsim.Image.init, array=test_arr, bounds=(1, 4, 1, 3))
+        assert_raises(TypeError, galsim.Image, bounds=(1, 4, 1, 3))
+        assert_raises(TypeError, galsim.Image, bounds=galsim.BoundsD(1, 4, 1, 3))
+        assert_raises(TypeError, galsim.Image, array=test_arr, bounds=(1, 4, 1, 3))
         assert_raises(
-            ValueError, galsim.Image.init, array=test_arr, bounds=galsim.BoundsI(1, 3, 1, 4)
+            ValueError, galsim.Image, array=test_arr, bounds=galsim.BoundsI(1, 3, 1, 4)
         )
         assert_raises(
-            ValueError, galsim.Image.init, array=test_arr, bounds=galsim.BoundsI(1, 4, 1, 1)
+            ValueError, galsim.Image, array=test_arr, bounds=galsim.BoundsI(1, 4, 1, 1)
         )
         # Invalid ncol, nrow
-        assert_raises(TypeError, galsim.Image.init, ncol=1.2, nrow=3)
-        assert_raises(TypeError, galsim.Image.init, ncol=2, nrow=3.4)
-        assert_raises(ValueError, galsim.Image.init, ncol="four", nrow="three")
+        assert_raises(TypeError, galsim.Image, ncol=1.2, nrow=3)
+        assert_raises(TypeError, galsim.Image, ncol=2, nrow=3.4)
+        assert_raises(ValueError, galsim.Image, ncol="four", nrow="three")
         # Invalid dtype
-        assert_raises(ValueError, galsim.Image.init, array=test_arr, dtype=bool)
-        assert_raises(ValueError, galsim.Image.init, array=test_arr.astype(bool))
+        assert_raises(ValueError, galsim.Image, array=test_arr, dtype=bool)
+        assert_raises(ValueError, galsim.Image, array=test_arr.astype(bool))
         # Invalid scale
-        assert_raises(ValueError, galsim.Image.init, 4, 3, scale="invalid")
+        assert_raises(ValueError, galsim.Image, 4, 3, scale="invalid")
         # Invalid wcs
-        assert_raises(TypeError, galsim.Image.init, 4, 3, wcs="invalid")
+        assert_raises(TypeError, galsim.Image, 4, 3, wcs="invalid")
         # Disallowed combinations
         assert_raises(
-            TypeError, galsim.Image.init, ncol=4, nrow=3, bounds=galsim.BoundsI(1, 4, 1, 3)
+            TypeError, galsim.Image, ncol=4, nrow=3, bounds=galsim.BoundsI(1, 4, 1, 3)
         )
-        assert_raises(TypeError, galsim.Image.init, ncol=4, nrow=3, array=test_arr)
-        assert_raises(TypeError, galsim.Image.init, ncol=4, nrow=3, image=test_im)
-        assert_raises(TypeError, galsim.Image.init, ncol=4)
-        assert_raises(TypeError, galsim.Image.init, nrow=3)
-        assert_raises(ValueError, galsim.Image.init, test_arr, bounds=galsim.BoundsI(1, 2, 1, 3))
+        assert_raises(TypeError, galsim.Image, ncol=4, nrow=3, array=test_arr)
+        assert_raises(TypeError, galsim.Image, ncol=4, nrow=3, image=test_im)
+        assert_raises(TypeError, galsim.Image, ncol=4)
+        assert_raises(TypeError, galsim.Image, nrow=3)
         assert_raises(
-            ValueError, galsim.Image.init, array=test_arr, bounds=galsim.BoundsI(1, 2, 1, 3)
+            ValueError, galsim.Image, test_arr, bounds=galsim.BoundsI(1, 2, 1, 3)
         )
-        assert_raises(ValueError, galsim.Image.init, [[1, 2]], bounds=galsim.BoundsI(1, 2, 1, 3))
-        assert_raises(TypeError, galsim.Image.init, test_arr, init_value=3)
-        assert_raises(TypeError, galsim.Image.init, array=test_arr, init_value=3)
-        assert_raises(TypeError, galsim.Image.init, test_im, init_value=3)
-        assert_raises(TypeError, galsim.Image.init, image=test_im, init_value=3)
-        assert_raises(TypeError, galsim.Image.init, dtype=float, init_value=3)
-        assert_raises(TypeError, galsim.Image.init, test_im, scale=3, wcs=galsim.PixelScale(3))
+        assert_raises(
+            ValueError, galsim.Image, array=test_arr, bounds=galsim.BoundsI(1, 2, 1, 3)
+        )
+        assert_raises(
+            ValueError, galsim.Image, [[1, 2]], bounds=galsim.BoundsI(1, 2, 1, 3)
+        )
+        assert_raises(TypeError, galsim.Image, test_arr, init_value=3)
+        assert_raises(TypeError, galsim.Image, array=test_arr, init_value=3)
+        assert_raises(TypeError, galsim.Image, test_im, init_value=3)
+        assert_raises(TypeError, galsim.Image, image=test_im, init_value=3)
+        assert_raises(TypeError, galsim.Image, dtype=float, init_value=3)
+        assert_raises(
+            TypeError, galsim.Image, test_im, scale=3, wcs=galsim.PixelScale(3)
+        )
         # Extra kwargs
-        assert_raises(TypeError, galsim.Image.init, image=test_im, name="invalid")
+        assert_raises(TypeError, galsim.Image, image=test_im, name="invalid")
 
 
 @timer
@@ -3048,7 +3229,9 @@ def test_Image_view():
         wcs=galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13)),
     )
     im._fill(17)
-    assert im.wcs == galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13))
+    assert im.wcs == galsim.AffineTransform(
+        0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13)
+    )
     assert im.bounds == galsim.BoundsI(1, 25, 1, 25)
     assert im(11, 19) == 17  # I'll keep editing this pixel to new values.
 
@@ -3076,8 +3259,12 @@ def test_Image_view():
 
     # Test view with new origin
     imv = im.view(origin=(0, 0))
-    assert im.wcs == galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13))
-    assert imv.wcs == galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(12, 12))
+    assert im.wcs == galsim.AffineTransform(
+        0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13)
+    )
+    assert imv.wcs == galsim.AffineTransform(
+        0.23, 0.01, -0.02, 0.22, galsim.PositionI(12, 12)
+    )
     assert im.bounds == galsim.BoundsI(1, 25, 1, 25)
     assert imv.bounds == galsim.BoundsI(0, 24, 0, 24)
     imv.setValue(10, 18, 30)
@@ -3098,8 +3285,12 @@ def test_Image_view():
 
     # Test view with new center
     imv = im.view(center=(0, 0))
-    assert im.wcs == galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13))
-    assert imv.wcs == galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(0, 0))
+    assert im.wcs == galsim.AffineTransform(
+        0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13)
+    )
+    assert imv.wcs == galsim.AffineTransform(
+        0.23, 0.01, -0.02, 0.22, galsim.PositionI(0, 0)
+    )
     assert im.bounds == galsim.BoundsI(1, 25, 1, 25)
     assert imv.bounds == galsim.BoundsI(-12, 12, -12, 12)
     imv.setValue(-2, 6, 40)
@@ -3122,7 +3313,9 @@ def test_Image_view():
 
     # Test view with new scale
     imv = im.view(scale=0.17)
-    assert im.wcs == galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13))
+    assert im.wcs == galsim.AffineTransform(
+        0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13)
+    )
     assert imv.wcs == galsim.PixelScale(0.17)
     assert imv.bounds == im.bounds
     imv.setValue(11, 19, 50)
@@ -3146,7 +3339,9 @@ def test_Image_view():
 
     # Test view with new wcs
     imv = im.view(wcs=galsim.JacobianWCS(0.0, 0.23, -0.23, 0.0))
-    assert im.wcs == galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13))
+    assert im.wcs == galsim.AffineTransform(
+        0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13)
+    )
     assert imv.wcs == galsim.JacobianWCS(0.0, 0.23, -0.23, 0.0)
     assert imv.bounds == im.bounds
     imv.setValue(11, 19, 60)
@@ -3171,11 +3366,10 @@ def test_Image_view():
     assert im.array.max() == 17
 
     assert_raises(TypeError, im.view, origin=(0, 0), center=(0, 0))
-    assert_raises(TypeError, im.view, scale=0.3, wcs=galsim.JacobianWCS(1.1, 0.1, 0.1, 1.0))
-    # JAX specific modification
-    # -------------------------
-    # PixelScale does not raise TypeError in JAX version to be jittable.
-    # assert_raises(TypeError, im.view, scale=galsim.PixelScale(0.3))
+    assert_raises(
+        TypeError, im.view, scale=0.3, wcs=galsim.JacobianWCS(1.1, 0.1, 0.1, 1.0)
+    )
+    assert_raises(TypeError, im.view, scale=galsim.PixelScale(0.3))
     assert_raises(TypeError, im.view, wcs=0.3)
 
 
@@ -3183,7 +3377,7 @@ def test_Image_view():
 def test_Image_writeheader():
     """Test the functionality of image.write(...) for images that have header attributes"""
     # First check: if we have an image.header attribute, it gets written to file.
-    im_test = galsim.Image.init(10, 10)
+    im_test = galsim.Image(10, 10)
     key_name = "test_key"
     im_test.header = galsim.FitsHeader(header={key_name: "test_val"})
     test_file = os.path.join(datadir, "test_header.fits")
@@ -3228,11 +3422,13 @@ def test_ne():
 def test_copy():
     """Test different ways to copy an Image."""
     wcs = galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13))
-    im = galsim.Image.init(25, 25, wcs=wcs)
+    im = galsim.Image(25, 25, wcs=wcs)
     gn = galsim.GaussianNoise(sigma=1.7)
     im.addNoise(gn)
 
-    assert im.wcs == galsim.AffineTransform(0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13))
+    assert im.wcs == galsim.AffineTransform(
+        0.23, 0.01, -0.02, 0.22, galsim.PositionI(13, 13)
+    )
     assert im.bounds == galsim.BoundsI(1, 25, 1, 25)
 
     # Simplest way to copy is copy()
@@ -3246,7 +3442,7 @@ def test_copy():
     assert im(3, 8) != 11.0
 
     # Can also use constructor to "copy"
-    im3 = galsim.Image.init(im)
+    im3 = galsim.Image(im)
     assert im3.wcs == im.wcs
     assert im3.bounds == im.bounds
     np.testing.assert_array_equal(im3.array, im.array)
@@ -3254,7 +3450,7 @@ def test_copy():
     assert im(3, 8) != 11.0
 
     # If copy=False is specified, then it shares the same array
-    im3b = galsim.Image.init(im, copy=False)
+    im3b = galsim.Image(im, copy=False)
     assert im3b.wcs == im.wcs
     assert im3b.bounds == im.bounds
     np.testing.assert_array_equal(im3b.array, im.array)
@@ -3263,21 +3459,21 @@ def test_copy():
     assert im(2, 3) == 2.0
 
     # Constructor can change the wcs
-    im4 = galsim.Image.init(im, scale=0.6)
+    im4 = galsim.Image(im, scale=0.6)
     assert im4.wcs != im.wcs  # wcs is not equal this time.
     assert im4.bounds == im.bounds
     np.testing.assert_array_equal(im4.array, im.array)
     im4.setValue(3, 8, 11.0)
     assert im(3, 8) != 11.0
 
-    im5 = galsim.Image.init(im, wcs=galsim.PixelScale(1.4))
+    im5 = galsim.Image(im, wcs=galsim.PixelScale(1.4))
     assert im5.wcs != im.wcs  # wcs is not equal this time.
     assert im5.bounds == im.bounds
     np.testing.assert_array_equal(im5.array, im.array)
     im5.setValue(3, 8, 11.0)
     assert im(3, 8) != 11.0
 
-    im6 = galsim.Image.init(im, wcs=wcs)
+    im6 = galsim.Image(im, wcs=wcs)
     assert im6.wcs == im.wcs  # This is the same wcs now.
     assert im6.bounds == im.bounds
     np.testing.assert_array_equal(im6.array, im.array)
@@ -3285,14 +3481,14 @@ def test_copy():
     assert im(3, 8) != 11.0
 
     # Can also change the dtype
-    im7 = galsim.Image.init(im, dtype=float)
+    im7 = galsim.Image(im, dtype=float)
     assert im7.wcs == im.wcs
     assert im7.bounds == im.bounds
     np.testing.assert_array_equal(im7.array, im.array)
     im7.setValue(3, 8, 11.0)
     assert im(3, 8) != 11.0
 
-    im8 = galsim.Image.init(im, wcs=wcs, dtype=float)
+    im8 = galsim.Image(im, wcs=wcs, dtype=float)
     assert im8.wcs == im.wcs  # This is the same wcs now.
     assert im8.bounds == im.bounds
     np.testing.assert_array_equal(im8.array, im.array)
@@ -3301,7 +3497,7 @@ def test_copy():
 
     # Check that a slice image copies correctly
     slice_array = large_array.astype(complex)[::3, ::2]
-    im_slice = galsim.Image.init(slice_array, wcs=wcs)
+    im_slice = galsim.Image(slice_array, wcs=wcs)
     im9 = im_slice.copy()
     assert im9.wcs == im_slice.wcs
     assert im9.bounds == im_slice.bounds
@@ -3311,7 +3507,7 @@ def test_copy():
     assert im_slice(2, 3) != 11.0
 
     # Can also copy by giving the array and specify copy=True
-    im10 = galsim.Image.init(im.array, bounds=im.bounds, wcs=im.wcs, copy=False)
+    im10 = galsim.Image(im.array, bounds=im.bounds, wcs=im.wcs, copy=False)
     assert im10.wcs == im.wcs
     assert im10.bounds == im.bounds
     np.testing.assert_array_equal(im10.array, im.array)
@@ -3319,7 +3515,7 @@ def test_copy():
     assert im10(2, 3) == 17.0
     assert im(2, 3) == 17.0
 
-    im10b = galsim.Image.init(im.array, bounds=im.bounds, wcs=im.wcs, copy=True)
+    im10b = galsim.Image(im.array, bounds=im.bounds, wcs=im.wcs, copy=True)
     assert im10b.wcs == im.wcs
     assert im10b.bounds == im.bounds
     np.testing.assert_array_equal(im10b.array, im.array)
@@ -3337,7 +3533,7 @@ def test_copy():
     assert im5(3, 8) == 11.0
 
     assert_raises(TypeError, im5.copyFrom, im8.array)
-    im9 = galsim.Image.init(5, 5, init_value=3)
+    im9 = galsim.Image(5, 5, init_value=3)
     assert_raises(ValueError, im5.copyFrom, im9)
 
 
@@ -3347,12 +3543,12 @@ def test_complex_image():
 
     for dtype in [np.complex64, np.complex128]:
         # Some complex modifications to tests in test_Image_basic
-        im1 = galsim.Image.init(ncol, nrow, dtype=dtype)
+        im1 = galsim.Image(ncol, nrow, dtype=dtype)
         im1_view = im1.view()
-        # im1_cview = im1.view(make_const=True) # JAX specific modification
-        im2 = galsim.Image.init(ncol, nrow, init_value=23, dtype=dtype)
+        im1_cview = im1.view(make_const=True)
+        im2 = galsim.Image(ncol, nrow, init_value=23, dtype=dtype)
         im2_view = im2.view()
-        # im2_cview = im2.view(make_const=True) # JAX specific modification
+        im2_cview = im2.view(make_const=True)
         im2_conj = im2.conjugate
 
         # Check various ways to set and get values
@@ -3363,18 +3559,18 @@ def test_complex_image():
                 # JAX specific modification
                 # -------------------------
                 # the view does not modify the parent array
-                # im2_cview.setValue(x, y, 100 + 10 * x + y + 13j * x + 23j * y)
                 im2.setValue(x, y, 100 + 10 * x + y + 13j * x + 23j * y)
+                im2_cview.setValue(x, y, 100 + 10 * x + y + 13j * x + 23j * y)
 
         for y in range(1, nrow + 1):
             for x in range(1, ncol + 1):
                 value = 100 + 10 * x + y + 13j * x + 23j * y
                 assert im1(x, y) == value
                 assert im1.view()(x, y) == value
-                # assert im1.view(make_const=True)(x, y) == value  # JAX specific modification
-                # assert im2_cview(x, y) == value
+                assert im1.view(make_const=True)(x, y) == value
                 assert im2(x, y) == value
-                # assert im2_view(x, y) == value
+                assert im2_view(x, y) == value
+                assert im2_cview(x, y) == value
                 assert im1.conjugate(x, y) == np.conjugate(value)
 
                 # complex conjugate is not a view into the original.
@@ -3387,31 +3583,28 @@ def test_complex_image():
                 # JAX specific modification
                 # -------------------------
                 # the view does not modify the parent array
-                # im2_cview.setValue(x=x, y=y, value=value2)
                 im2.setValue(x=x, y=y, value=value2)
+                im2_cview.setValue(x=x, y=y, value=value2)
 
                 assert im1(x, y) == value2
                 assert im1.view()(x, y) == value2
-                # JAX specific modification
-                # assert im1.view(make_const=True)(x, y) == value2
+                assert im1.view(make_const=True)(x, y) == value2
                 assert im2(x, y) == value2
                 assert im2_view(x, y) == value2
-                # assert im2_cview(x, y) == value2
+                assert im2_cview(x, y) == value2
 
                 assert im1.real(x, y) == value2.real
                 assert im1.view().real(x, y) == value2.real
-                # JAX specific modification
-                # assert im1.view(make_const=True).real(x, y) == value2.real
-                # assert im2_cview.real(x, y) == value2.real
+                assert im1.view(make_const=True).real(x, y) == value2.real
                 assert im2.real(x, y) == value2.real
                 assert im2_view.real(x, y) == value2.real
+                assert im2_cview.real(x, y) == value2.real
                 assert im1.imag(x, y) == value2.imag
                 assert im1.view().imag(x, y) == value2.imag
-                # JAX specific modification
-                # assert im1.view(make_const=True).imag(x, y) == value2.imag
-                # assert im2_cview.imag(x, y) == value2.imag
+                assert im1.view(make_const=True).imag(x, y) == value2.imag
                 assert im2.imag(x, y) == value2.imag
                 assert im2_view.imag(x, y) == value2.imag
+                assert im2_cview.imag(x, y) == value2.imag
                 assert im1.conjugate(x, y) == np.conjugate(value2)
                 assert im2.conjugate(x, y) == np.conjugate(value2)
 
@@ -3436,9 +3629,9 @@ def test_complex_image():
                 # assert im2.conjugate(x,y) == np.conjugate(value3)
 
         # Check view of given data
-        im3_view = galsim.Image.init((1 + 2j) * ref_array.astype(complex))
+        im3_view = galsim.Image((1 + 2j) * ref_array.astype(complex))
         slice_array = (large_array * (1 + 2j)).astype(complex)[::3, ::2]
-        im4_view = galsim.Image.init(slice_array)
+        im4_view = galsim.Image(slice_array)
         for y in range(1, nrow + 1):
             for x in range(1, ncol + 1):
                 assert im3_view(x, y) == 10 * x + y + 20j * x + 2j * y
@@ -3720,7 +3913,7 @@ def test_complex_image_arith():
 def test_int_image_arith():
     """Additional arithmetic tests that are relevant for integer Image types"""
     for i in range(int_ntypes):
-        full = galsim.Image.init(ref_array.astype(types[i]))
+        full = galsim.Image(ref_array.astype(types[i]))
         hi = (full // 8) * 8
         lo = full % 8
 
@@ -4009,7 +4202,7 @@ def test_int_image_arith():
 
         # A subset of the above for cross-type checks.
         for j in range(i):
-            full2 = galsim.Image.init(ref_array.astype(types[j]))
+            full2 = galsim.Image(ref_array.astype(types[j]))
             hi2 = (full2 // 8) * 8
             lo2 = full2 % 8
 
@@ -4018,14 +4211,16 @@ def test_int_image_arith():
             np.testing.assert_array_equal(
                 test.array,
                 hi.array,
-                err_msg="& failed for Images with dtypes = %s, %s." % (types[i], types[j]),
+                err_msg="& failed for Images with dtypes = %s, %s."
+                % (types[i], types[j]),
             )
             # hi &= full => hi
             test &= full2
             np.testing.assert_array_equal(
                 test.array,
                 hi.array,
-                err_msg="&= failed for Images with dtypes = %s, %s." % (types[i], types[j]),
+                err_msg="&= failed for Images with dtypes = %s, %s."
+                % (types[i], types[j]),
             )
 
             # lo | lo = lo
@@ -4033,7 +4228,8 @@ def test_int_image_arith():
             np.testing.assert_array_equal(
                 test.array,
                 lo.array,
-                err_msg="| failed for Images with dtypes = %s, %s." % (types[i], types[j]),
+                err_msg="| failed for Images with dtypes = %s, %s."
+                % (types[i], types[j]),
             )
 
             # lo |= hi => full
@@ -4041,7 +4237,8 @@ def test_int_image_arith():
             np.testing.assert_array_equal(
                 test.array,
                 full.array,
-                err_msg="|= failed for Images with dtypes = %s, %s." % (types[i], types[j]),
+                err_msg="|= failed for Images with dtypes = %s, %s."
+                % (types[i], types[j]),
             )
 
             # lo ^ hi = full
@@ -4049,7 +4246,8 @@ def test_int_image_arith():
             np.testing.assert_array_equal(
                 test.array,
                 full.array,
-                err_msg="^ failed for Images with dtypes = %s, %s." % (types[i], types[j]),
+                err_msg="^ failed for Images with dtypes = %s, %s."
+                % (types[i], types[j]),
             )
 
             # full ^= lo => hi
@@ -4057,7 +4255,8 @@ def test_int_image_arith():
             np.testing.assert_array_equal(
                 test.array,
                 hi.array,
-                err_msg="^= failed for Images with dtypes = %s, %s." % (types[i], types[j]),
+                err_msg="^= failed for Images with dtypes = %s, %s."
+                % (types[i], types[j]),
             )
 
             # lo // hi = 0
@@ -4161,7 +4360,7 @@ def test_int_image_arith():
 def test_wrap():
     """Test the image.wrap() function."""
     # Start with a fairly simple test where the image is 4 copies of the same data:
-    im_orig = galsim.Image.init(
+    im_orig = galsim.Image(
         [
             [11.0, 12.0, 13.0, 14.0, 11.0, 12.0, 13.0, 14.0],
             [21.0, 22.0, 23.0, 24.0, 21.0, 22.0, 23.0, 24.0],
@@ -4228,7 +4427,9 @@ def test_wrap():
     np.testing.assert_array_equal(
         im_wrap.array, im[b].array, "image.wrap(%s) did not return the right subimage"
     )
-    np.testing.assert_equal(im_wrap.bounds, b, "image.wrap(%s) does not have the correct bounds")
+    np.testing.assert_equal(
+        im_wrap.bounds, b, "image.wrap(%s) does not have the correct bounds"
+    )
 
     # For complex images (in particular k-space images), we often want the image to be implicitly
     # Hermitian, so we only need to keep around half of it.
@@ -4237,8 +4438,12 @@ def test_wrap():
     K = 8
     L = 5
     im = galsim.ImageCD(2 * M + 1, 2 * N + 1, xmin=-M, ymin=-N)  # Explicitly Hermitian
-    im2 = galsim.ImageCD(2 * M + 1, N + 1, xmin=-M, ymin=0)  # Implicitly Hermitian across y axis
-    im3 = galsim.ImageCD(M + 1, 2 * N + 1, xmin=0, ymin=-N)  # Implicitly Hermitian across x axis
+    im2 = galsim.ImageCD(
+        2 * M + 1, N + 1, xmin=-M, ymin=0
+    )  # Implicitly Hermitian across y axis
+    im3 = galsim.ImageCD(
+        M + 1, 2 * N + 1, xmin=0, ymin=-N
+    )  # Implicitly Hermitian across x axis
     # print('im = ',im)
     # print('im2 = ',im2)
     # print('im3 = ',im3)
@@ -4279,7 +4484,9 @@ def test_wrap():
     np.testing.assert_array_equal(
         im_wrap.array, im[b].array, "image.wrap(%s) did not return the right subimage"
     )
-    np.testing.assert_equal(im_wrap.bounds, b, "image.wrap(%s) does not have the correct bounds")
+    np.testing.assert_equal(
+        im_wrap.bounds, b, "image.wrap(%s) does not have the correct bounds"
+    )
 
     im2_wrap = im2.wrap(b2, hermitian="y")
     # print('im_test = ',im_test[b2].array)
@@ -4296,7 +4503,9 @@ def test_wrap():
         im2[b2].array,
         "image.wrap(%s) did not return the right subimage",
     )
-    np.testing.assert_equal(im2_wrap.bounds, b2, "image.wrap(%s) does not have the correct bounds")
+    np.testing.assert_equal(
+        im2_wrap.bounds, b2, "image.wrap(%s) does not have the correct bounds"
+    )
 
     im3_wrap = im3.wrap(b3, hermitian="x")
     # print('im_test = ',im_test[b3].array)
@@ -4313,7 +4522,9 @@ def test_wrap():
         im3[b3].array,
         "image.wrap(%s) did not return the right subimage",
     )
-    np.testing.assert_equal(im3_wrap.bounds, b3, "image.wrap(%s) does not have the correct bounds")
+    np.testing.assert_equal(
+        im3_wrap.bounds, b3, "image.wrap(%s) does not have the correct bounds"
+    )
 
     b = galsim.BoundsI(-K + 1, K, -L + 1, L)
     b2 = galsim.BoundsI(-K + 1, K, 0, L)
@@ -4390,7 +4601,9 @@ def test_bin():
     np.testing.assert_almost_equal(
         ar3b.sum(), im2.array.sum(), 6, "direct binning didn't perserve total flux"
     )
-    np.testing.assert_almost_equal(ar3b, im3.array, 6, "direct binning didn't match bin function.")
+    np.testing.assert_almost_equal(
+        ar3b, im3.array, 6, "direct binning didn't match bin function."
+    )
     np.testing.assert_almost_equal(
         im3.array.sum(), im2.array.sum(), 6, "bin didn't preserve the total flux"
     )
@@ -4400,7 +4613,9 @@ def test_bin():
         6,
         "2x2 binned image doesn't match image with 2x2 larger pixels",
     )
-    np.testing.assert_almost_equal(im3.scale, im1.scale, 6, "bin resulted in wrong scale")
+    np.testing.assert_almost_equal(
+        im3.scale, im1.scale, 6, "bin resulted in wrong scale"
+    )
 
     im4 = im2.subsample(2, 2)
     np.testing.assert_almost_equal(
@@ -4416,7 +4631,9 @@ def test_bin():
         6,
         "Round trip subsample then bin 2x2 doesn't match original",
     )
-    np.testing.assert_almost_equal(im5.scale, im2.scale, 6, "round trip resulted in wrong scale")
+    np.testing.assert_almost_equal(
+        im5.scale, im2.scale, 6, "round trip resulted in wrong scale"
+    )
 
     # Next do nx != ny.  And wcs = JacobianWCS
     wcs1 = galsim.JacobianWCS(0.6, 0.14, 0.15, 0.7)
@@ -4446,7 +4663,9 @@ def test_bin():
     np.testing.assert_almost_equal(
         ar3b.sum(), im2.array.sum(), 6, "direct binning didn't perserve total flux"
     )
-    np.testing.assert_almost_equal(ar3b, im3.array, 6, "direct binning didn't match bin function.")
+    np.testing.assert_almost_equal(
+        ar3b, im3.array, 6, "direct binning didn't match bin function."
+    )
     np.testing.assert_almost_equal(
         im3.array.sum(), im2.array.sum(), 6, "bin didn't preserve the total flux"
     )
@@ -4552,7 +4771,9 @@ def test_fpack():
     """Test the functionality that we advertise as being equivalent to fpack/funpack"""
     from astropy.io import fits
 
-    file_name0 = os.path.join("tests/GalSim/tests/des_data", "DECam_00158414_01.fits.fz")
+    file_name0 = os.path.join(
+        "tests/GalSim/tests/des_data", "DECam_00158414_01.fits.fz"
+    )
     hdulist = fits.open(file_name0)
 
     # Remove a few invalid header keys in the DECam fits file
@@ -4571,10 +4792,14 @@ def test_fpack():
     file_name3 = os.path.join("tests/output", "DECam_00158414_01.fits.fz")
 
     # This line basically does funpack:
-    galsim.fits.writeMulti(galsim.fits.readMulti(file_name1, read_headers=True), file_name2)
+    galsim.fits.writeMulti(
+        galsim.fits.readMulti(file_name1, read_headers=True), file_name2
+    )
 
     # This line basically does fpack:
-    galsim.fits.writeMulti(galsim.fits.readMulti(file_name2, read_headers=True), file_name3)
+    galsim.fits.writeMulti(
+        galsim.fits.readMulti(file_name2, read_headers=True), file_name3
+    )
 
     # Check that the final file is essentially equivalent to the original.
     imlist1 = galsim.fits.readMulti(file_name1, read_headers=True)

--- a/tests/jax/test_jitting.py
+++ b/tests/jax/test_jitting.py
@@ -120,7 +120,7 @@ def test_image_jitting():
             [15, 25, 35, 45, 55, 65, 75],
         ]
     ).astype(dtype=jnp.float32)
-    im1 = galsim.Image.init(ref_array, wcs=galsim.PixelScale(0.2), dtype=jnp.int32)
+    im1 = galsim.Image(ref_array, wcs=galsim.PixelScale(0.2), dtype=jnp.int32)
     assert identity(im1) == im1
 
 


### PR DESCRIPTION
This PR aims to revert some of the recent changes that have modified the API for galsim.Image. The hope here is that we can retain the original API, while making sure we can still jit and vmap when and where we need it.