### PR TITLE
REF use our own implements decorator

### DIFF
--- a/.github/workflows/python_package.yaml
+++ b/.github/workflows/python_package.yaml
@@ -33,12 +33,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pre-commit
+          python -m pip install pytest
           python -m pip install .
-
-      - name: Run pre-commit
-        run: |
-          pre-commit run --all-files --show-diff-on-failure
 
       - name: Test with pytest
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,14 @@
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: false
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: monthly
+    skip: []
+    submodules: false
+
 repos:
   - repo: https://github.com/psf/black
     rev: 23.9.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ However, most JAX-GalSim function will directly inherit the documentation from t
 
 ```python
 import galsim as _galsim
-from jax._src.numpy.util import implements
+from jax_galsim.core.utils import implements
 from jax.tree_util import register_pytree_node_class
 
 @implements(_galsim.Add,
@@ -157,7 +157,7 @@ Note that this tool has the option of providing a `lax_description` which will b
 
 ### Flattening and Unflattening of objects
 
-In order to be able to use JAX transformations, we need to be able to flatten and unflatten objects. This happens within the `tree_flatten` and `tree_unflatten` methods. 
+In order to be able to use JAX transformations, we need to be able to flatten and unflatten objects. This happens within the `tree_flatten` and `tree_unflatten` methods.
 The unflattening can fail to work as expected when type checks are performed in the `__init__` method of a given object. To avoid this issue, the following strategy can used:
 
 https://jax.readthedocs.io/en/latest/pytrees.html#custom-pytrees-and-initialization

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **JAX port of GalSim, for parallelized, GPU accelerated, and differentiable galaxy image simulations.**
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) [![Python package](https://github.com/GalSim-developers/JAX-GalSim/actions/workflows/python_package.yaml/badge.svg)](https://github.com/GalSim-developers/JAX-GalSim/actions/workflows/python_package.yaml) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) [![Python package](https://github.com/GalSim-developers/JAX-GalSim/actions/workflows/python_package.yaml/badge.svg)](https://github.com/GalSim-developers/JAX-GalSim/actions/workflows/python_package.yaml) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/GalSim-developers/JAX-GalSim/main.svg)](https://results.pre-commit.ci/latest/github/GalSim-developers/JAX-GalSim/main)
 
 **Disclaimer**: This project is still in an early development phase, **please use the [reference GalSim implementation](https://github.com/GalSim-developers/GalSim) for any scientific applications.**
 

--- a/jax_galsim/angle.py
+++ b/jax_galsim/angle.py
@@ -19,10 +19,9 @@
 # SOFTWARE.
 import galsim as _galsim
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
-from jax_galsim.core.utils import cast_to_float, ensure_hashable
+from jax_galsim.core.utils import cast_to_float, ensure_hashable, implements
 
 
 @implements(_galsim.AngleUnit)

--- a/jax_galsim/bessel.py
+++ b/jax_galsim/bessel.py
@@ -1,8 +1,9 @@
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from tensorflow_probability.substrates.jax.math import bessel_kve as _tfp_bessel_kve
+
+from jax_galsim.core.utils import implements
 
 
 # the code here for Si, f, g and _si_small_pade is taken from galsim/src/math/Sinc.cpp

--- a/jax_galsim/bounds.py
+++ b/jax_galsim/bounds.py
@@ -1,10 +1,14 @@
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
-from jax_galsim.core.utils import cast_to_float, cast_to_int, ensure_hashable
+from jax_galsim.core.utils import (
+    cast_to_float,
+    cast_to_int,
+    ensure_hashable,
+    implements,
+)
 from jax_galsim.position import Position, PositionD, PositionI
 
 BOUNDS_LAX_DESCR = """\

--- a/jax_galsim/box.py
+++ b/jax_galsim/box.py
@@ -1,10 +1,9 @@
 import galsim as _galsim
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.core.draw import draw_by_kValue, draw_by_xValue
-from jax_galsim.core.utils import ensure_hashable
+from jax_galsim.core.utils import ensure_hashable, implements
 from jax_galsim.gsobject import GSObject
 from jax_galsim.random import UniformDeviate
 

--- a/jax_galsim/celestial.py
+++ b/jax_galsim/celestial.py
@@ -24,11 +24,10 @@ import coord as _coord
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.angle import Angle, _Angle, arcsec, degrees, radians
-from jax_galsim.core.utils import ensure_hashable
+from jax_galsim.core.utils import ensure_hashable, implements
 
 
 # we have to copy this one since JAX sends in `t` as a traced array

--- a/jax_galsim/convolve.py
+++ b/jax_galsim/convolve.py
@@ -1,9 +1,9 @@
 import galsim as _galsim
 import jax.numpy as jnp
 from galsim.errors import galsim_warn
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
+from jax_galsim.core.utils import implements
 from jax_galsim.gsobject import GSObject
 from jax_galsim.gsparams import GSParams
 from jax_galsim.photon_array import PhotonArray

--- a/jax_galsim/core/utils.py
+++ b/jax_galsim/core/utils.py
@@ -1,7 +1,7 @@
 import re
 import textwrap
 from functools import partial
-from typing import Any, Callable, NamedTuple
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -290,11 +290,11 @@ class ParsedDoc(NamedTuple):
     sections: dictionary of section titles to section content.
     """
 
-    docstr: str = ""
-    signature: str = ""
-    summary: str = ""
-    front_matter: str = ""
-    sections: dict[str, str] = {}
+    docstr = ""
+    signature = ""
+    summary = ""
+    front_matter = ""
+    sections = {}
 
 
 def _break_off_body_section_by_newline(body):
@@ -322,7 +322,7 @@ def _break_off_body_section_by_newline(body):
     return firstline, body
 
 
-def _parse_galsimdoc(docstr: str | None) -> ParsedDoc:
+def _parse_galsimdoc(docstr):
     """Parse a standard galsim-style docstring.
 
     Args:
@@ -380,10 +380,10 @@ def _parse_galsimdoc(docstr: str | None) -> ParsedDoc:
 
 
 def implements(
-    original_fun: Callable[..., Any] | None,
-    lax_description: str = "",
-    module: str | None = None,
-) -> Callable[..., Any]:
+    original_fun,
+    lax_description="",
+    module=None,
+):
     """Decorator for JAX functions which implement a specified GalSim function.
 
     This mainly contains logic to copy and modify the docstring of the original

--- a/jax_galsim/core/utils.py
+++ b/jax_galsim/core/utils.py
@@ -1,4 +1,7 @@
+import re
+import textwrap
 from functools import partial
+from typing import Any, Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -252,3 +255,198 @@ def bisect_for_root(func, low, high, niter=75):
     fhigh = func(high)
     args = (func, low, flow, high, fhigh)
     return jax.lax.fori_loop(0, niter, _func, args)[-2]
+
+
+# start of code from https://github.com/google/jax/blob/main/jax/_src/numpy/util.py #
+# used with modifications for galsim under the following licnese:
+# fmt: off
+#
+#    Copyright 2020 The JAX Authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# fmt: on
+
+_galsim_signature_re = re.compile(r"^([\w., ]+=)?\s*[\w\.]+\([\w\W]*?\)$", re.MULTILINE)
+_docreference = re.compile(r":doc:`(.*?)\s*<.*?>`")
+
+
+class ParsedDoc(NamedTuple):
+    """
+    docstr: full docstring
+    signature: signature from docstring.
+    summary: summary from docstring.
+    front_matter: front matter before sections.
+    sections: dictionary of section titles to section content.
+    """
+
+    docstr: str | None
+    signature: str = ""
+    summary: str = ""
+    front_matter: str = ""
+    sections: dict[str, str] = {}
+
+
+def _break_off_body_section_by_newline(body):
+    first_lines = []
+    body_lines = []
+    found_first_break = False
+    for line in body.split("\n"):
+        if not first_lines:
+            first_lines.append(line)
+            continue
+
+        if not line.strip() and not found_first_break:
+            found_first_break = True
+            continue
+
+        if found_first_break:
+            body_lines.append(line)
+        else:
+            first_lines.append(line)
+
+    firstline = "\n".join(first_lines)
+    body = "\n".join(body_lines)
+    body = textwrap.dedent(body.lstrip("\n"))
+
+    return firstline, body
+
+
+def _parse_galsimdoc(docstr: str | None) -> ParsedDoc:
+    """Parse a standard galsim-style docstring.
+
+    Args:
+        docstr: the raw docstring from a function
+    Returns:
+        ParsedDoc: parsed version of the docstring
+    """
+    if docstr is None or not docstr.strip():
+        return ParsedDoc(docstr)
+
+    # Remove any :doc: directives in the docstring to avoid sphinx errors
+    docstr = _docreference.sub(lambda match: f"{match.groups()[0]}", docstr)
+
+    signature, body = "", docstr
+    match = _galsim_signature_re.match(body)
+    if match:
+        signature = match.group()
+        body = docstr[match.end() :]
+
+    firstline, body = _break_off_body_section_by_newline(body)
+
+    match = _galsim_signature_re.match(body)
+    if match:
+        signature = match.group()
+        body = body[match.end() :]
+
+    summary = firstline
+    if not summary:
+        summary, body = _break_off_body_section_by_newline(body)
+
+    front_matter_lines = []
+    body_lines = []
+    found_params = False
+    for line in body.split("\n"):
+        if not found_params and line.lstrip().startswith("Parameters:"):
+            found_params = True
+
+        if found_params:
+            body_lines.append(line)
+        else:
+            front_matter_lines.append(line)
+    front_matter = "\n".join(front_matter_lines)
+    body = "\n".join(body_lines)
+
+    # we add back the body for now, but keep code above if we parse params in the future
+    front_matter = front_matter + "\n" + body
+
+    return ParsedDoc(
+        docstr=docstr,
+        signature=signature,
+        summary=summary,
+        front_matter=front_matter,
+        sections={},
+    )
+
+
+def implements(
+    original_fun: Callable[..., Any] | None,
+    lax_description: str = "",
+    module: str | None = None,
+) -> Callable[..., Any]:
+    """Decorator for JAX functions which implement a specified GalSim function.
+
+    This mainly contains logic to copy and modify the docstring of the original
+    function. In particular, if `update_doc` is True, parameters listed in the
+    original function that are not supported by the decorated function will
+    be removed from the docstring. For this reason, it is important that parameter
+    names match those in the original GalSim function.
+
+    Parameters:
+        original_fun:     The original function being implemented
+        lax_description:  A string description that will be added to the beginning of
+                          the docstring.
+        module:           An optional string specifying the module from which the original function
+                          is imported. This is useful for objects, where the module cannot
+                          be determined from the original function itself.
+    """
+
+    def decorator(wrapped_fun):
+        wrapped_fun.__galsim_wrapped__ = original_fun
+
+        # Allows this pattern: @implements(getattr(np, 'new_function', None))
+        if original_fun is None:
+            if lax_description:
+                wrapped_fun.__doc__ = lax_description
+            return wrapped_fun
+
+        docstr = getattr(original_fun, "__doc__", None)
+        name = getattr(
+            original_fun, "__name__", getattr(wrapped_fun, "__name__", str(wrapped_fun))
+        )
+        try:
+            mod = module or original_fun.__module__
+        except AttributeError:
+            pass
+        else:
+            name = f"{mod}.{name}"
+
+        if docstr:
+            try:
+                parsed = _parse_galsimdoc(docstr)
+
+                docstr = parsed.summary.strip() + "\n" if parsed.summary else ""
+                docstr += f"\nLAX-backend implementation of :func:`{name}`.\n"
+                if lax_description:
+                    docstr += "\n" + lax_description.strip() + "\n"
+                docstr += "\n*Original docstring below.*\n"
+
+                if parsed.front_matter:
+                    docstr += "\n" + parsed.front_matter.strip() + "\n"
+            except Exception:
+                docstr = original_fun.__doc__
+
+        wrapped_fun.__doc__ = docstr
+        for attr in ["__name__", "__qualname__"]:
+            try:
+                value = getattr(original_fun, attr)
+            except AttributeError:
+                pass
+            else:
+                setattr(wrapped_fun, attr, value)
+        return wrapped_fun
+
+    return decorator
+
+
+# end of code from https://github.com/google/jax/blob/main/jax/_src/numpy/util.py #

--- a/jax_galsim/core/utils.py
+++ b/jax_galsim/core/utils.py
@@ -290,11 +290,11 @@ class ParsedDoc(NamedTuple):
     sections: dictionary of section titles to section content.
     """
 
-    docstr = ""
-    signature = ""
-    summary = ""
-    front_matter = ""
-    sections = {}
+    docstr: str = ""
+    signature: str = ""
+    summary: str = ""
+    front_matter: str = ""
+    sections: dict[str, str] = {}
 
 
 def _break_off_body_section_by_newline(body):

--- a/jax_galsim/core/utils.py
+++ b/jax_galsim/core/utils.py
@@ -258,7 +258,7 @@ def bisect_for_root(func, low, high, niter=75):
 
 
 # start of code from https://github.com/google/jax/blob/main/jax/_src/numpy/util.py #
-# used with modifications for galsim under the following licnese:
+# used with modifications for galsim under the following license:
 # fmt: off
 #
 #    Copyright 2020 The JAX Authors.

--- a/jax_galsim/core/utils.py
+++ b/jax_galsim/core/utils.py
@@ -290,7 +290,7 @@ class ParsedDoc(NamedTuple):
     sections: dictionary of section titles to section content.
     """
 
-    docstr: str | None
+    docstr: str = ""
     signature: str = ""
     summary: str = ""
     front_matter: str = ""

--- a/jax_galsim/deltafunction.py
+++ b/jax_galsim/deltafunction.py
@@ -1,11 +1,10 @@
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.core.draw import draw_by_kValue, draw_by_xValue
-from jax_galsim.core.utils import ensure_hashable
+from jax_galsim.core.utils import ensure_hashable, implements
 from jax_galsim.gsobject import GSObject
 
 

--- a/jax_galsim/deprecated.py
+++ b/jax_galsim/deprecated.py
@@ -1,8 +1,8 @@
 import warnings
 
 import galsim as _galsim
-from jax._src.numpy.util import implements
 
+from jax_galsim.core.utils import implements
 from jax_galsim.errors import GalSimDeprecationWarning
 
 

--- a/jax_galsim/exponential.py
+++ b/jax_galsim/exponential.py
@@ -1,10 +1,9 @@
 import galsim as _galsim
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.core.draw import draw_by_kValue, draw_by_xValue
-from jax_galsim.core.utils import ensure_hashable
+from jax_galsim.core.utils import ensure_hashable, implements
 from jax_galsim.gsobject import GSObject
 from jax_galsim.random import UniformDeviate
 from jax_galsim.utilities import lazy_property

--- a/jax_galsim/fits.py
+++ b/jax_galsim/fits.py
@@ -6,8 +6,8 @@ import jax.numpy as jnp
 import numpy as np
 from galsim.fits import FitsHeader, closeHDUList, readFile, writeFile  # noqa: F401
 from galsim.utilities import galsim_warn
-from jax._src.numpy.util import implements
 
+from jax_galsim.core.utils import implements
 from jax_galsim.image import Image
 
 # We wrap the galsim FITS read functions to return jax_galsim Image objects.

--- a/jax_galsim/fitswcs.py
+++ b/jax_galsim/fitswcs.py
@@ -5,13 +5,17 @@ import galsim as _galsim
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim import fits
 from jax_galsim.angle import AngleUnit, arcsec, degrees, radians
 from jax_galsim.celestial import CelestialCoord
-from jax_galsim.core.utils import cast_to_float, cast_to_python_float, ensure_hashable
+from jax_galsim.core.utils import (
+    cast_to_float,
+    cast_to_python_float,
+    ensure_hashable,
+    implements,
+)
 from jax_galsim.errors import (
     GalSimError,
     GalSimIncompatibleValuesError,
@@ -51,7 +55,7 @@ from jax_galsim.wcs import (
     _galsim.fitswcs.GSFitsWCS,
     lax_description=(
         "The JAX-GalSim version of this class does not raise errors if inverting the WCS to "
-        "map ra,dec to (x,y) fails. Instead it returns NaNs.",
+        "map ra,dec to (x,y) fails. Instead it returns NaNs."
     ),
 )
 @register_pytree_node_class

--- a/jax_galsim/gaussian.py
+++ b/jax_galsim/gaussian.py
@@ -1,10 +1,9 @@
 import galsim as _galsim
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.core.draw import draw_by_kValue, draw_by_xValue
-from jax_galsim.core.utils import ensure_hashable
+from jax_galsim.core.utils import ensure_hashable, implements
 from jax_galsim.gsobject import GSObject
 from jax_galsim.random import GaussianDeviate
 

--- a/jax_galsim/gsobject.py
+++ b/jax_galsim/gsobject.py
@@ -5,11 +5,10 @@ import galsim as _galsim
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax._src.numpy.util import implements
 
 import jax_galsim.photon_array as pa
 from jax_galsim.core.draw import calculate_n_photons
-from jax_galsim.core.utils import is_equal_with_arrays
+from jax_galsim.core.utils import implements, is_equal_with_arrays
 from jax_galsim.errors import (
     GalSimError,
     GalSimIncompatibleValuesError,

--- a/jax_galsim/gsparams.py
+++ b/jax_galsim/gsparams.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 
 import galsim as _galsim
-from jax._src.numpy.util import implements
+
+from jax_galsim.core.utils import implements
 
 
 @implements(_galsim.GSParams)

--- a/jax_galsim/image.py
+++ b/jax_galsim/image.py
@@ -1,11 +1,10 @@
 import galsim as _galsim
 import jax.numpy as jnp
 import numpy as np
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.bounds import Bounds, BoundsD, BoundsI
-from jax_galsim.core.utils import ensure_hashable
+from jax_galsim.core.utils import ensure_hashable, implements
 from jax_galsim.errors import GalSimImmutableError
 from jax_galsim.position import PositionI
 from jax_galsim.utilities import parse_pos_args

--- a/jax_galsim/interpolant.py
+++ b/jax_galsim/interpolant.py
@@ -11,11 +11,10 @@ import galsim as _galsim
 import jax
 import jax.numpy as jnp
 from galsim.errors import GalSimValueError
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.bessel import si
-from jax_galsim.core.utils import is_equal_with_arrays
+from jax_galsim.core.utils import implements, is_equal_with_arrays
 from jax_galsim.errors import GalSimError
 from jax_galsim.gsparams import GSParams
 from jax_galsim.random import UniformDeviate

--- a/jax_galsim/interpolatedimage.py
+++ b/jax_galsim/interpolatedimage.py
@@ -14,12 +14,15 @@ from galsim.errors import (
     GalSimValueError,
 )
 from galsim.utilities import doc_inherit
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim import fits
 from jax_galsim.bounds import BoundsI
-from jax_galsim.core.utils import compute_major_minor_from_jacobian, ensure_hashable
+from jax_galsim.core.utils import (
+    compute_major_minor_from_jacobian,
+    ensure_hashable,
+    implements,
+)
 from jax_galsim.gsobject import GSObject
 from jax_galsim.gsparams import GSParams
 from jax_galsim.image import Image

--- a/jax_galsim/moffat.py
+++ b/jax_galsim/moffat.py
@@ -1,7 +1,6 @@
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import Partial as partial
 from jax.tree_util import register_pytree_node_class
 
@@ -9,7 +8,7 @@ from jax_galsim.bessel import kv
 from jax_galsim.core.bessel import j0
 from jax_galsim.core.draw import draw_by_kValue, draw_by_xValue
 from jax_galsim.core.integrate import ClenshawCurtisQuad, quad_integral
-from jax_galsim.core.utils import bisect_for_root, ensure_hashable
+from jax_galsim.core.utils import bisect_for_root, ensure_hashable, implements
 from jax_galsim.gsobject import GSObject
 from jax_galsim.position import PositionD
 from jax_galsim.random import UniformDeviate

--- a/jax_galsim/noise.py
+++ b/jax_galsim/noise.py
@@ -1,10 +1,9 @@
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
-from jax_galsim.core.utils import cast_to_float, ensure_hashable
+from jax_galsim.core.utils import cast_to_float, ensure_hashable, implements
 from jax_galsim.errors import GalSimError, GalSimIncompatibleValuesError
 from jax_galsim.image import Image, ImageD
 from jax_galsim.random import BaseDeviate, GaussianDeviate, PoissonDeviate

--- a/jax_galsim/photon_array.py
+++ b/jax_galsim/photon_array.py
@@ -4,10 +4,9 @@ import galsim as _galsim
 import jax
 import jax.numpy as jnp
 import jax.random as jrng
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
-from jax_galsim.core.utils import cast_to_python_int
+from jax_galsim.core.utils import cast_to_python_int, implements
 from jax_galsim.errors import (
     GalSimIncompatibleValuesError,
     GalSimRangeError,

--- a/jax_galsim/position.py
+++ b/jax_galsim/position.py
@@ -1,10 +1,14 @@
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
-from jax_galsim.core.utils import cast_to_float, cast_to_int, ensure_hashable
+from jax_galsim.core.utils import (
+    cast_to_float,
+    cast_to_int,
+    ensure_hashable,
+    implements,
+)
 
 
 @implements(_galsim.Position)

--- a/jax_galsim/random.py
+++ b/jax_galsim/random.py
@@ -5,8 +5,9 @@ import galsim as _galsim
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
+
+from jax_galsim.core.utils import implements
 
 try:
     from jax.extend.random import wrap_key_data

--- a/jax_galsim/sensor.py
+++ b/jax_galsim/sensor.py
@@ -1,7 +1,7 @@
 import galsim as _galsim
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
+from jax_galsim.core.utils import implements
 from jax_galsim.errors import GalSimUndefinedBoundsError
 from jax_galsim.position import PositionI
 

--- a/jax_galsim/shear.py
+++ b/jax_galsim/shear.py
@@ -1,11 +1,10 @@
 import galsim as _galsim
 import jax.numpy as jnp
 from galsim.errors import GalSimIncompatibleValuesError
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.angle import Angle, _Angle, radians
-from jax_galsim.core.utils import ensure_hashable
+from jax_galsim.core.utils import ensure_hashable, implements
 
 
 @register_pytree_node_class

--- a/jax_galsim/spergel.py
+++ b/jax_galsim/spergel.py
@@ -1,13 +1,12 @@
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import Partial as partial
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.bessel import kv
 from jax_galsim.core.draw import draw_by_kValue, draw_by_xValue
-from jax_galsim.core.utils import bisect_for_root, ensure_hashable
+from jax_galsim.core.utils import bisect_for_root, ensure_hashable, implements
 from jax_galsim.gsobject import GSObject
 from jax_galsim.random import UniformDeviate
 from jax_galsim.utilities import lazy_property

--- a/jax_galsim/sum.py
+++ b/jax_galsim/sum.py
@@ -2,9 +2,9 @@ import galsim as _galsim
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
+from jax_galsim.core.utils import implements
 from jax_galsim.gsobject import GSObject
 from jax_galsim.gsparams import GSParams
 from jax_galsim.position import PositionD

--- a/jax_galsim/transform.py
+++ b/jax_galsim/transform.py
@@ -1,10 +1,13 @@
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
-from jax_galsim.core.utils import compute_major_minor_from_jacobian, ensure_hashable
+from jax_galsim.core.utils import (
+    compute_major_minor_from_jacobian,
+    ensure_hashable,
+    implements,
+)
 from jax_galsim.gsobject import GSObject
 from jax_galsim.gsparams import GSParams
 from jax_galsim.position import PositionD

--- a/jax_galsim/utilities.py
+++ b/jax_galsim/utilities.py
@@ -3,9 +3,8 @@ import functools
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 
-from jax_galsim.core.utils import has_tracers
+from jax_galsim.core.utils import has_tracers, implements
 from jax_galsim.errors import GalSimIncompatibleValuesError, GalSimValueError
 from jax_galsim.position import PositionD, PositionI
 

--- a/jax_galsim/wcs.py
+++ b/jax_galsim/wcs.py
@@ -1,11 +1,10 @@
 import galsim as _galsim
 import jax.numpy as jnp
-from jax._src.numpy.util import implements
 from jax.tree_util import register_pytree_node_class
 
 from jax_galsim.angle import AngleUnit, arcsec, radians
 from jax_galsim.celestial import CelestialCoord
-from jax_galsim.core.utils import cast_to_python_float, ensure_hashable
+from jax_galsim.core.utils import cast_to_python_float, ensure_hashable, implements
 from jax_galsim.errors import GalSimValueError
 from jax_galsim.gsobject import GSObject
 from jax_galsim.position import Position, PositionD, PositionI

--- a/tests/jax/test_implements.py
+++ b/tests/jax/test_implements.py
@@ -9,7 +9,7 @@ def test_implements_parse_galsimdoc():
 
     assert p.signature == ""
     assert p.summary == "A class describing a 2D Gaussian surface brightness profile."
-    assert "is characterized by two propertie" in p.front_matter
+    assert "is characterized by two properties" in p.front_matter
     assert "Parameters:" in p.front_matter
     assert p.sections == {}
 

--- a/tests/jax/test_implements.py
+++ b/tests/jax/test_implements.py
@@ -1,0 +1,48 @@
+from jax_galsim.core.utils import implements, _parse_galsimdoc
+from galsim import Gaussian as _Gaussian
+
+
+def test_implements_parse_galsimdoc():
+    docstring = _Gaussian.__doc__
+    p = _parse_galsimdoc(docstring)
+
+    assert p.signature == ""
+    assert p.summary == "A class describing a 2D Gaussian surface brightness profile."
+    assert "is characterized by two propertie" in p.front_matter
+    assert "Parameters:" in p.front_matter
+    assert p.sections == {}
+
+
+class TestImplements:
+    """The summary is
+    cool.
+
+    This is front matter.
+
+    Parameters:
+        blah:    here we go again
+    """
+    pass
+
+@implements(TestImplements, lax_description="This is a lax description")
+class LAXTestImplements:
+    pass
+
+
+def test_implements():
+    docstring = TestImplements.__doc__
+    p = _parse_galsimdoc(docstring)
+
+    assert p.signature == ""
+    assert p.summary == "The summary is\n    cool."
+    assert "This is front matter." in p.front_matter
+    assert "LAX" not in p.front_matter
+    assert p.sections == {}
+
+    docstring = LAXTestImplements.__doc__
+    p = _parse_galsimdoc(docstring)
+    assert p.signature == ""
+    assert p.summary == "The summary is\n    cool."
+    assert "This is front matter." in p.front_matter
+    assert "LAX" in p.front_matter
+    assert p.sections == {}


### PR DESCRIPTION
This PR switches the code to use our own decorator for wrapping doc strings from GalSim. It doesn't yet support all of the options from the one in jax, but it removes our dependence on a non-public API. I also enabled pre-commit for easy formatting fixes. 

closes #93 