### PR TITLE
PERF block reduce in wrapping

### DIFF
--- a/jax_galsim/core/wrap_image.py
+++ b/jax_galsim/core/wrap_image.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 
 @partial(jax.jit, static_argnames=("nxwrap", "nywrap"))
 def _block_reduce_index(sim, nxwrap, nywrap):
+    # this routine was written by Jean-Eric Campagne w/ edits and comments by Matthew Becker
     def rolling_window_i(arr, wind):
         idx = (
             jnp.arange(arr.shape[0] - wind + 1)[::wind, None]

--- a/jax_galsim/core/wrap_image.py
+++ b/jax_galsim/core/wrap_image.py
@@ -1,37 +1,46 @@
-# from functools import partial
+from functools import partial
+
 import jax
 import jax.numpy as jnp
 
 
-@jax.jit
+@partial(jax.jit, static_argnames=("xmin", "ymin", "nxwrap", "nywrap"))
 def wrap_nonhermitian(im, xmin, ymin, nxwrap, nywrap):
-    def _body_j(j, vals):
-        i, im = vals
+    # these bits compute how many total blocks we need to cover the image
+    nx = im.shape[1] // nxwrap
+    if im.shape[1] % nxwrap:
+        nx += 1
 
-        ii = (i - ymin) % nywrap + ymin
-        jj = (j - xmin) % nxwrap + xmin
+    ny = im.shape[0] // nywrap
+    if im.shape[0] % nywrap:
+        ny += 1
 
-        im = jax.lax.cond(
-            # weird way to say if ii != i and jj != j
-            # I tried other ways and got test failures
-            jnp.abs(ii - i) + jnp.abs(jj - j) != 0,
-            lambda im, i, j, ii, jj: im.at[ii, jj].add(im[i, j]),
-            lambda im, i, j, ii, jj: im,
-            im,
-            i,
-            j,
-            ii,
-            jj,
-        )
+    # we have to pad to the correct size to get a whole number of blocks
+    sim = jnp.pad(im, ((0, ny * nywrap - im.shape[0]), (0, nx * nxwrap - im.shape[1])))
 
-        return [i, im]
+    # then we roll the array so that the blocks start at the (0, 0) corner
+    # this makes the indexing below super clean and fast
+    sim = jnp.roll(sim, (-ymin, -xmin), axis=(0, 1))
 
-    def _body_i(i, vals):
-        im = vals
-        _, im = jax.lax.fori_loop(0, im.shape[1], _body_j, [i, im])
-        return im
+    # we do the reduction into another array and then set the final result in im at the end
+    fim = jnp.zeros((nywrap, nxwrap), dtype=im.dtype)
 
-    im = jax.lax.fori_loop(0, im.shape[0], _body_i, im)
+    # this set of loops will be explicitly unrolled by JAX when it compiles the function
+    # via JIT
+    # the number of iterations (i.e., blocks) should be small enough that this is OK
+    yl = 0
+    for _ in range(ny):
+        yh = yl + nywrap
+
+        xl = 0
+        for _ in range(nx):
+            xh = xl + nxwrap
+            fim = fim + sim[yl:yh, xl:xh]
+            xl = xh
+
+        yl = yh
+
+    im = im.at[ymin : ymin + nywrap, xmin : xmin + nxwrap].set(fim)
     return im
 
 
@@ -45,7 +54,17 @@ def contract_hermitian_x(im):
     return im[:, im.shape[1] // 2 :]
 
 
-@jax.jit
+@partial(
+    jax.jit,
+    static_argnames=[
+        "im_xmin",
+        "im_ymin",
+        "wrap_xmin",
+        "wrap_ymin",
+        "wrap_nx",
+        "wrap_ny",
+    ],
+)
 def wrap_hermitian_x(im, im_xmin, im_ymin, wrap_xmin, wrap_ymin, wrap_nx, wrap_ny):
     im_exp = expand_hermitian_x(im)
     im_exp = wrap_nonhermitian(
@@ -64,76 +83,20 @@ def contract_hermitian_y(im):
     return im[im.shape[0] // 2 :, :]
 
 
-@jax.jit
+@partial(
+    jax.jit,
+    static_argnames=[
+        "im_xmin",
+        "im_ymin",
+        "wrap_xmin",
+        "wrap_ymin",
+        "wrap_nx",
+        "wrap_ny",
+    ],
+)
 def wrap_hermitian_y(im, im_xmin, im_ymin, wrap_xmin, wrap_ymin, wrap_nx, wrap_ny):
     im_exp = expand_hermitian_y(im)
     im_exp = wrap_nonhermitian(
         im_exp, wrap_xmin - im_xmin, wrap_ymin - im_ymin, wrap_nx, wrap_ny
     )
     return contract_hermitian_y(im_exp)
-
-
-# I am leaving this code here for posterity. It has a bug that I cannot find.
-# It tries to be more clever instead of simply expanding the hermitian image to
-# it's full shape, wrapping everything, and then contracting. -MRB
-# @jax.jit
-# def wrap_hermitian_x(im, im_xmin, im_ymin, wrap_xmin, wrap_ymin, wrap_nx, wrap_ny):
-#     def _body_j(j, vals):
-#         i, im = vals
-
-#         # first do zero or positive x freq
-#         im_y = i + im_ymin
-#         im_x = j + im_xmin
-#         wrap_y = (im_y - wrap_ymin) % wrap_ny + wrap_ymin
-#         wrap_x = (im_x - wrap_xmin) % wrap_nx + wrap_xmin
-#         wrap_yind = wrap_y - im_ymin
-#         wrap_xind = wrap_x - im_xmin
-#         im = jax.lax.cond(
-#             wrap_xind >= 0,
-#             lambda wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind: jax.lax.cond(
-#                 jnp.abs(wrap_x - im_x) + jnp.abs(wrap_y - im_y) != 0,
-#                 lambda im, wrap_yind, wrap_xind: im.at[wrap_yind, wrap_xind].add(im[i, j]),
-#                 lambda im, wrap_yind, wrap_xind: im,
-#                 im,
-#                 wrap_yind,
-#                 wrap_xind,
-#             ),
-#             lambda wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind: im,
-#             wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind,
-#         )
-
-#         # now do neg x freq
-#         im_y = -im_y
-#         im_x = -im_x
-#         wrap_y = (im_y - wrap_ymin) % wrap_ny + wrap_ymin
-#         wrap_x = (im_x - wrap_xmin) % wrap_nx + wrap_xmin
-#         wrap_yind = wrap_y - im_ymin
-#         wrap_xind = wrap_x - im_xmin
-#         im = jax.lax.cond(
-#             im_x != 0,
-#             lambda wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind: jax.lax.cond(
-#                 wrap_xind >= 0,
-#                 lambda wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind: jax.lax.cond(
-#                     (jnp.abs(wrap_x - im_x) + jnp.abs(wrap_y - im_y)) != 0,
-#                     lambda im, wrap_yind, wrap_xind: im.at[wrap_yind, wrap_xind].add(im[i, j].conjugate()),
-#                     lambda im, wrap_yind, wrap_xind: im,
-#                     im,
-#                     wrap_yind,
-#                     wrap_xind,
-#                 ),
-#                 lambda wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind: im,
-#                 wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind,
-#             ),
-#             lambda wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind: im,
-#             wrap_x, im_x, wrap_y, im_y, im, wrap_yind, wrap_xind,
-#         )
-
-#         return [i, im]
-
-#     def _body_i(i, vals):
-#         im = vals
-#         _, im = jax.lax.fori_loop(0, im.shape[1], _body_j, [i, im])
-#         return im
-
-#     im = jax.lax.fori_loop(0, im.shape[0], _body_i, im)
-#     return im

--- a/tests/jax/test_image_wrapping.py
+++ b/tests/jax/test_image_wrapping.py
@@ -123,6 +123,10 @@ def test_image_wrapping_autodiff():
         for j in range(-N, N + 1):
             assert im(i, j) == im(-i, -j).conjugate()
 
+    # make sure it runs once
+    b3 = galsim.BoundsI(0, K, -L + 1, L)
+    im.wrap(b3)
+
     @jax.jit
     def _wrapit(im):
         b3 = galsim.BoundsI(0, K, -L + 1, L)


### PR DESCRIPTION
This PR uses a block-wise reduction algorithm for wrapping images. It should fix the performance issues of our previous double for loop. 

fixes #96 