### PR TITLE
perf: use vmap for iimage

### DIFF
--- a/jax_galsim/interpolant.py
+++ b/jax_galsim/interpolant.py
@@ -1464,8 +1464,11 @@ class Lanczos(Interpolant):
     @classmethod
     def tree_unflatten(cls, aux_data, children):
         """Recreates an instance of the class from flattened representation"""
-        n = aux_data.pop("n")
-        return cls(n, **aux_data)
+        return cls(
+            aux_data["n"],
+            gsparams=aux_data["gsparams"],
+            conserve_dc=aux_data["conserve_dc"],
+        )
 
     def __repr__(self):
         return "galsim.Lanczos(%r, %r, gsparams=%r)" % (

--- a/jax_galsim/interpolatedimage.py
+++ b/jax_galsim/interpolatedimage.py
@@ -965,6 +965,17 @@ def _xValue_arr(x, y, x_offset, y_offset, xmin, ymin, arr, x_interpolant):
     return vals
 
 
+@partial(jax.vmap, in_axes=(0, None, None, None, None, None))
+@partial(jax.jit, static_argnames=("interp",))
+def _interp_weight_1d_xval(ioff, xi, xp, x, nx, interp):
+    xind = xi + ioff
+    mskx = (xind >= 0) & (xind < nx)
+    _x = x - (xp + ioff)
+    wx = interp._xval_noraise(_x)
+    wx = jnp.where(mskx, wx, 0)
+    return wx, xind.astype(jnp.int32)
+
+
 @partial(jax.jit, static_argnames=("interp",))
 def _draw_with_interpolant_xval(x, y, xmin, ymin, zp, interp):
     """This helper function interpolates an image (`zp`) with an interpolant `interp`
@@ -998,61 +1009,28 @@ def _draw_with_interpolant_xval(x, y, xmin, ymin, zp, interp):
     yp = yi + ymin
     ny = zp.shape[0]
 
-    # this function is the inner loop over the x direction
-    # the variables are
-    #  i: the index of the location in the interpolation kernel
-    #  z: the final interpolated values
-    #  wy: the weight of the interpolation kernel in the y direction
-    #  msky: a mask that is true if the y index is in bounds
-    #  yind: the y index of the interpolation point needed by the kernel
-    def _body_1d(i, args):
-        z, wy, msky, yind, xi, xp, zp = args
+    wx, xind = _interp_weight_1d_xval(
+        jnp.arange(-interp.xrange, interp.xrange + 1),
+        xi,
+        xp,
+        x,
+        nx,
+        interp,
+    )
 
-        # this block computes the x weight using the
-        # offset in the interpolation kernel i
-        xind = xi + i
-        mskx = (xind >= 0) & (xind < nx)
-        _x = x - (xp + i)
-        wx = interp._xval_noraise(_x)
+    wy, yind = _interp_weight_1d_xval(
+        jnp.arange(-interp.xrange, interp.xrange + 1),
+        yi,
+        yp,
+        y,
+        ny,
+        interp,
+    )
 
-        # the actual interpolation is done here.
-        # we use jnp.where to only do the interpolation
-        # where the x and y indices are in bounds.
-        # the total weight is the product of the x and y weights.
-        w = wx * wy
-        msk = msky & mskx
-        z += jnp.where(msk, zp[yind, xind] * w, 0)
-
-        return [z, wy, msky, yind, xi, xp, zp]
-
-    # this function is the outer loop over the y direction
-    # the variables are
-    #  i: the index of the location in the interpolation kernel
-    #  z: the final interpolated values
-    def _body(i, args):
-        z, xi, yi, xp, yp, zp = args
-
-        # this block computes the x weight using the
-        # offset in the interpolation kernel i
-        yind = yi + i
-        msk = (yind >= 0) & (yind < ny)
-        _y = y - (yp + i)
-        wy = interp._xval_noraise(_y)
-
-        # this call computes the interpolant for each x locatoon that gets
-        # paired with this y location
-        z = jax.lax.fori_loop(
-            -interp.xrange, interp.xrange + 1, _body_1d, [z, wy, msk, yind, xi, xp, zp]
-        )[0]
-        return [z, xi, yi, xp, yp, zp]
-
-    # the actual loop call for y is here
-    z = jax.lax.fori_loop(
-        -interp.xrange,
-        interp.xrange + 1,
-        _body,
-        [jnp.zeros(x.shape, dtype=float), xi, yi, xp, yp, zp],
-    )[0]
+    z = jnp.sum(
+        wx[None, :, :] * wy[:, None, :] * zp[yind[:, None, :], xind[None, :, :]],
+        axis=(0, 1),
+    )
 
     # we reshape on the way out to match the input shape
     return z.reshape(orig_shape)
@@ -1099,6 +1077,15 @@ def _kValue_arr(
     return jnp.where(msk, val * xint_val * pfac, 0.0)
 
 
+@partial(jax.vmap, in_axes=(0, None, None, None, None, None))
+@partial(jax.jit, static_argnames=("interp",))
+def _interp_weight_1d_kval(ioff, kxi, kxp, kx, nkx, interp):
+    kxind = (kxi + ioff) % nkx
+    _kx = kx - (kxp + ioff)
+    wkx = interp._xval_noraise(_kx)
+    return wkx, kxind.astype(jnp.int32)
+
+
 @partial(jax.jit, static_argnames=("interp",))
 def _draw_with_interpolant_kval(kx, ky, kxmin, kymin, zp, interp):
     """This function interpolates complex k-space images and follows the
@@ -1126,51 +1113,50 @@ def _draw_with_interpolant_kval(kx, ky, kxmin, kymin, zp, interp):
     kyp = kyi + kymin
     nky = zp.shape[0]
 
-    def _body_1d(i, args):
-        z, wky, kyind, kxi, nkx, nkx_2, kxp, zp = args
+    wkx, kxind = _interp_weight_1d_kval(
+        jnp.arange(-interp.xrange, interp.xrange + 1),
+        kxi,
+        kxp,
+        kx,
+        nkx,
+        interp,
+    )
 
-        kxind = (kxi + i) % nkx
-        _kx = kx - (kxp + i)
-        wkx = interp._xval_noraise(_kx)
+    wky, kyind = _interp_weight_1d_kval(
+        jnp.arange(-interp.xrange, interp.xrange + 1),
+        kyi,
+        kyp,
+        ky,
+        nky,
+        interp,
+    )
 
-        # this is the key difference from the xval function
-        # we need to use the Hermitian symmetry to get the
-        # values that are not in memory
-        # in memory we have the values at nkx_2 to nkx - 1
-        # the Hermitian symmetry is that
-        #   f(ky, kx) = conjugate(f(-kx, -ky))
-        # In indices this is a symmetric flip about the central
-        # pixels at kx = ky = 0.
-        # we do not need to mask any values that run off the edge of the image
-        # since we rewrap them using the periodicity of the image.
-        val = jnp.where(
-            kxind < nkx_2,
-            zp[(nky - kyind) % nky, nkx - kxind - nkx_2].conjugate(),
-            zp[kyind, kxind - nkx_2],
-        )
-        z += val * wkx * wky
+    wkx = wkx[None, :, :]
+    kxind = kxind[None, :, :]
+    wky = wky[:, None, :]
+    kyind = kyind[:, None, :]
 
-        return [z, wky, kyind, kxi, nkx, nkx_2, kxp, zp]
+    # this is the key difference from the xval function
+    # we need to use the Hermitian symmetry to get the
+    # values that are not in memory
+    # in memory we have the values at nkx_2 to nkx - 1
+    # the Hermitian symmetry is that
+    #   f(ky, kx) = conjugate(f(-kx, -ky))
+    # In indices this is a symmetric flip about the central
+    # pixels at kx = ky = 0.
+    # we do not need to mask any values that run off the edge of the image
+    # since we rewrap them using the periodicity of the image.
 
-    def _body(i, args):
-        z, kxi, kyi, nky, nkx, nkx_2, kxp, kyp, zp = args
-        kyind = (kyi + i) % nky
-        _ky = ky - (kyp + i)
-        wky = interp._xval_noraise(_ky)
-        z = jax.lax.fori_loop(
-            -interp.xrange,
-            interp.xrange + 1,
-            _body_1d,
-            [z, wky, kyind, kxi, nkx, nkx_2, kxp, zp],
-        )[0]
-        return [z, kxi, kyi, nky, nkx, nkx_2, kxp, kyp, zp]
+    val = jnp.where(
+        kxind < nkx_2,
+        zp[(nky - kyind) % nky, nkx - kxind - nkx_2].conjugate(),
+        zp[kyind, kxind - nkx_2],
+    )
+    z = jnp.sum(
+        val * wkx * wky,
+        axis=(0, 1),
+    )
 
-    z = jax.lax.fori_loop(
-        -interp.xrange,
-        interp.xrange + 1,
-        _body,
-        [jnp.zeros(kx.shape, dtype=complex), kxi, kyi, nky, nkx, nkx_2, kxp, kyp, zp],
-    )[0]
     return z.reshape(orig_shape)
 
 

--- a/jax_galsim/interpolatedimage.py
+++ b/jax_galsim/interpolatedimage.py
@@ -1116,8 +1116,11 @@ def _draw_with_interpolant_kval(kx, ky, kxmin, kymin, zp, interp):
     kyp = kyi + kymin
     nky = zp.shape[0]
 
+    irange = interp.ixrange // 2
+    iinds = jnp.arange(-irange, irange + 1)
+
     wkx, kxind = _interp_weight_1d_kval(
-        jnp.arange(-interp.xrange, interp.xrange + 1),
+        iinds,
         kxi,
         kxp,
         kx,
@@ -1126,7 +1129,7 @@ def _draw_with_interpolant_kval(kx, ky, kxmin, kymin, zp, interp):
     )
 
     wky, kyind = _interp_weight_1d_kval(
-        jnp.arange(-interp.xrange, interp.xrange + 1),
+        iinds,
         kyi,
         kyp,
         ky,

--- a/jax_galsim/interpolatedimage.py
+++ b/jax_galsim/interpolatedimage.py
@@ -1009,8 +1009,11 @@ def _draw_with_interpolant_xval(x, y, xmin, ymin, zp, interp):
     yp = yi + ymin
     ny = zp.shape[0]
 
+    irange = interp.ixrange // 2
+    iinds = jnp.arange(-irange, irange + 1)
+
     wx, xind = _interp_weight_1d_xval(
-        jnp.arange(-interp.xrange, interp.xrange + 1),
+        iinds,
         xi,
         xp,
         x,
@@ -1019,7 +1022,7 @@ def _draw_with_interpolant_xval(x, y, xmin, ymin, zp, interp):
     )
 
     wy, yind = _interp_weight_1d_xval(
-        jnp.arange(-interp.xrange, interp.xrange + 1),
+        iinds,
         yi,
         yp,
         y,


### PR DESCRIPTION
This PR switches the code to vmap for interpolated images in order to increase performance.