### PR TITLE
refactor: do interpolation class init on the host

### DIFF
--- a/jax_galsim/interpolant.py
+++ b/jax_galsim/interpolant.py
@@ -5,11 +5,13 @@ interpolants themselves (e.g., the coefficients that define the kernel
 shapes, the integrals of the kernels, etc.) are constants.
 """
 
+import functools
 import math
 
 import galsim as _galsim
 import jax
 import jax.numpy as jnp
+import numpy as np
 from galsim.errors import GalSimValueError
 from jax.tree_util import register_pytree_node_class
 
@@ -262,7 +264,7 @@ class Interpolant:
     @property
     def krange(self):
         """The maximum extent of the interpolant in Fourier space (in 1/pixels)."""
-        return 2.0 * jnp.pi * self.urange()
+        return 2.0 * np.pi * self.urange()
 
     def urange(self):
         """The maximum extent of the interpolant in Fourier space (in 2pi/pixels)."""
@@ -390,7 +392,7 @@ class Nearest(Interpolant):
 
     def urange(self):
         """The maximum extent of the interpolant in Fourier space (in 2pi/pixels)."""
-        return 1.0 / (jnp.pi * self._gsparams.kvalue_accuracy)
+        return 1.0 / (np.pi * self._gsparams.kvalue_accuracy)
 
     @property
     def xrange(self):
@@ -407,6 +409,35 @@ class Nearest(Interpolant):
         photons.x = ud.generate(photons.x) - 0.5
         photons.y = ud.generate(photons.y) - 0.5
         photons.flux = 1.0 / photons.size()
+
+
+@np.vectorize
+def _gs_si(x):
+    return _galsim.bessel.si(x)
+
+
+@functools.lru_cache(maxsize=128)
+def _sinc_unit_integrals(ixrange):
+    n = ixrange // 2 + 1
+    narr = np.arange(n + 1)
+    sivals = _gs_si(np.pi * (narr - 0.5))
+    _unit_integrals = (sivals[1:] - sivals[:-1]) / np.pi
+    return _unit_integrals[:n]
+
+
+@functools.lru_cache(maxsize=128)
+def _sinc_fluxes(ixrange):
+    # the sinc function oscillates so we want to integrate over an even number of periods
+    n = ixrange // 2 + 1
+    if n % 2 != 0:
+        n += 1
+    narr = np.arange(n + 1)
+    sivals = _gs_si(np.pi * narr)
+    val = (sivals[1:] - sivals[:-1]) / np.pi
+
+    _positive_flux = np.sum(np.where(val > 0, val, 0.0)) * 2.0
+    _negative_flux = _positive_flux - 1.0
+    return _positive_flux, _negative_flux
 
 
 @implements(_galsim.interpolant.SincInterpolant)
@@ -441,7 +472,7 @@ class SincInterpolant(Interpolant):
     def xrange(self):
         """The maximum extent of the interpolant from the origin (in pixels)."""
         # Technically infinity, but truncated by the tolerance.
-        return 1.0 / (jnp.pi * self._gsparams.kvalue_accuracy)
+        return 1.0 / (np.pi * self._gsparams.kvalue_accuracy)
 
     def unit_integrals(self, max_len=None):
         """Compute the unit integrals of the real-space kernel.
@@ -456,27 +487,10 @@ class SincInterpolant(Interpolant):
         """
         n = self.ixrange // 2 + 1
         n = n if max_len is None else min(n, max_len)
-        if not hasattr(self, "_unit_integrals") or n > len(self._unit_integrals):
-            narr = jnp.arange(n)
-            # these are constants so we do not propagate gradients
-            self._unit_integrals = jax.lax.stop_gradient(
-                (si(jnp.pi * (narr + 0.5)) - si(jnp.pi * (narr - 0.5))) / jnp.pi
-            )
-        return self._unit_integrals[:n]
+        return _sinc_unit_integrals(self.ixrange)[:n]
 
     def _comp_fluxes(self):
-        # the sinc function oscillates so we want to integrate over an even number of periods
-        n = self.ixrange // 2 + 1
-        if n % 2 != 0:
-            n += 1
-        narr = jnp.arange(n)
-
-        val = (si(jnp.pi * (narr + 1)) - si(jnp.pi * (narr))) / jnp.pi
-        # this computed flux is a constant and so we do not propagate gradients
-        self._positive_flux = (
-            jax.lax.stop_gradient(jnp.sum(jnp.where(val > 0, val, 0.0))) * 2.0
-        )
-        self._negative_flux = self._positive_flux - 1.0
+        self._positive_flux, self._negative_flux = _sinc_fluxes(self.ixrange)
 
     def _shoot(self, photons, rng):
         raise GalSimError(
@@ -492,7 +506,7 @@ class Linear(Interpolant):
     _negative_flux = 0.0
     # from galsim itself via
     # >>> galsim.Linear().unit_integrals()
-    _unit_integrals = jnp.array([0.75, 0.125], dtype=float)
+    _unit_integrals = np.array([0.75, 0.125], dtype=float)
 
     def __init__(self, tol=None, gsparams=None):
         if tol is not None:
@@ -518,7 +532,7 @@ class Linear(Interpolant):
 
     def urange(self):
         """The maximum extent of the interpolant in Fourier space (in 2pi/pixels)."""
-        return 1.0 / jnp.sqrt(self._gsparams.kvalue_accuracy) / jnp.pi
+        return 1.0 / np.sqrt(self._gsparams.kvalue_accuracy) / np.pi
 
     @property
     def xrange(self):
@@ -545,7 +559,7 @@ class Cubic(Interpolant):
     _positive_flux = 13.0 / 12.0
     _negative_flux = 1.0 / 12.0
     # from galsim itself via the source at galsim.interpolant.Cubic
-    _unit_integrals = jnp.array([161.0 / 192, 3.0 / 32, -5.0 / 384], dtype=float)
+    _unit_integrals = np.array([161.0 / 192, 3.0 / 32, -5.0 / 384], dtype=float)
 
     def __init__(self, tol=None, gsparams=None):
         if tol is not None:
@@ -585,10 +599,10 @@ class Cubic(Interpolant):
         """The maximum extent of the interpolant in Fourier space (in 2pi/pixels)."""
         # magic formula from galsim CPP layer in src/Interpolant.cpp
         return (
-            jnp.power(
-                (3.0 * jnp.sqrt(3.0) / 8.0) / self._gsparams.kvalue_accuracy, 1.0 / 3.0
+            np.power(
+                (3.0 * np.sqrt(3.0) / 8.0) / self._gsparams.kvalue_accuracy, 1.0 / 3.0
             )
-            / jnp.pi
+            / np.pi
         )
 
     @property
@@ -610,7 +624,7 @@ class Quintic(Interpolant):
     _positive_flux = 1.1293413499280066555
     _negative_flux = 0.1293413499280066555
     # from galsim itself via `galsim.Quintic().unit_integrals()`
-    _unit_integrals = jnp.array(
+    _unit_integrals = np.array(
         [
             0.8724826228119177,
             0.07332899380883082,
@@ -679,11 +693,11 @@ class Quintic(Interpolant):
         """The maximum extent of the interpolant in Fourier space (in 2pi/pixels)."""
         # magic formula from galsim CPP layer in src/Interpolant.cpp
         return (
-            jnp.power(
-                (25.0 * jnp.sqrt(5.0) / 108.0) / self._gsparams.kvalue_accuracy,
+            np.power(
+                (25.0 * np.sqrt(5.0) / 108.0) / self._gsparams.kvalue_accuracy,
                 1.0 / 3.0,
             )
-            / jnp.pi
+            / np.pi
         )
 
     @property
@@ -833,58 +847,58 @@ class Lanczos(Interpolant):
 
     # fmt: off
     _unit_integrals_no_conserve_dc = {
-        1: jnp.array([0.7736950099028163, 0.0645641638701392], dtype=float),
-        2: jnp.array([
+        1: np.array([0.7736950099028163, 0.0645641638701392], dtype=float),
+        2: np.array([
             0.8465887094380671, 0.09303749006303791,
             -0.011436924726642468], dtype=float),
-        3: jnp.array([
+        3: np.array([
             0.8609564689315261, 0.0854975941631095,
             -0.02198305969046234, 0.0045349041140008714], dtype=float),
-        4: jnp.array([
+        4: np.array([
             0.866051828001578, 0.08164164710461341,
             -0.0211168606127283, 0.009485060642921659,
             -0.0024077071164748673], dtype=float),
-        5: jnp.array([
+        5: np.array([
             0.8684220505647028, 0.07961972252745429,
             -0.020016735819945855, 0.009558891823702252,
             -0.005184575956143513, 0.0014879848847649067], dtype=float),
-        6: jnp.array([
+        6: np.array([
             0.8697127191238894, 0.07845585622633226,
             -0.01920340255869482, 0.009237930102390803,
             -0.005384978311733045, 0.0032356834836430046,
             -0.001009369059991005], dtype=float),
-        7: jnp.array([
+        7: np.array([
             8.7049202177269380e-01, 7.7731321479942828e-02,
             -1.8633958804874725e-02, 8.8979604030649008e-03,
             -5.3109613153060203e-03, 3.4211298515002897e-03,
             -2.1994566985353557e-03, 7.2920194182248238e-04], dtype=float),
-        8: jnp.array([
+        8: np.array([
             8.7099825045836277e-01, 7.7251798117792966e-02,
             -1.8231183550600525e-02, 8.6123371774333903e-03,
             -5.1683105487452634e-03, 3.4297387648459152e-03,
             -2.3495038301018420e-03, 1.5869647419779489e-03,
             -5.5126917083166398e-04], dtype=float),
-        9: jnp.array([
+        9: np.array([
             8.7134551547294570e-01, 7.6918789259528400e-02,
             -1.7939545253488193e-02, 8.3851399529145665e-03,
             -5.0223675581809370e-03, 3.3740587008968420e-03,
             -2.3845688672012753e-03, 1.7048998137498051e-03,
             -1.1964980987349909e-03, 4.3128985494303028e-04], dtype=float),
-        10: jnp.array([
+        10: np.array([
             8.7159401009600912e-01, 7.6678458714107514e-02,
             -1.7723066666894282e-02, 8.2063352309026966e-03,
             -4.8921265119170072e-03, 3.2995228350380813e-03,
             -2.3686328888224547e-03, 1.7460701688724418e-03,
             -1.2891159996234734e-03, 9.3303369245166100e-04,
             -3.4658944544847537e-04], dtype=float),
-        11: jnp.array([
+        11: np.array([
             8.7177792063920001e-01, 7.6499493089007983e-02,
             -1.7558618559349929e-02, 8.0650477479507002e-03,
             -4.7811660243816710e-03, 3.2241347417886492e-03,
             -2.3318307976264293e-03, 1.7484791053141236e-03,
             -1.3289789960901517e-03, 1.0063792430271374e-03,
             -7.4723017598378385e-04, 2.8458455048163499e-04], dtype=float),
-        12: jnp.array([
+        12: np.array([
             8.7191782966320464e-01, 7.6362719513935945e-02,
             -1.7431083730257708e-02, 7.9523619355260939e-03,
             -4.6881497744781127e-03, 3.1545680896655440e-03,
@@ -892,7 +906,7 @@ class Lanczos(Interpolant):
             -1.3396107940286301e-03, 1.0424634183502162e-03,
             -8.0597292403970474e-04, 6.1147711864485818e-04,
             -2.3783833713667121e-04], dtype=float),
-        13: jnp.array([
+        13: np.array([
             8.7202672970489126e-01, 7.6255884824415227e-02,
             -1.7330351693013456e-02, 7.8614942460054384e-03,
             -4.6104639074225039e-03, 3.0927905379740887e-03,
@@ -900,7 +914,7 @@ class Lanczos(Interpolant):
             -1.3344523827163023e-03, 1.0563945723023067e-03,
             -8.3773694673650576e-04, 6.5908595977630401e-04,
             -5.0937905883310702e-04, 2.0172731901756032e-04], dtype=float),
-        14: jnp.array([
+        14: np.array([
             8.7211314971773835e-01, 7.6170869830959512e-02,
             -1.7249497299346866e-02, 7.7873949593983190e-03,
             -4.5454533508222910e-03, 3.0388526410040475e-03,
@@ -909,7 +923,7 @@ class Lanczos(Interpolant):
             -8.5254662631379762e-04, 6.8672453302556010e-04,
             -5.4841096286049721e-04, 4.3071793405843433e-04,
             -1.7325480547849065e-04], dtype=float),
-        15: jnp.array([
+        15: np.array([
             8.7218287617389989e-01, 7.6102125928469905e-02,
             -1.7183668054715523e-02, 7.7263146760676790e-03,
             -4.4907973134569864e-03, 2.9920817097864516e-03,
@@ -918,7 +932,7 @@ class Lanczos(Interpolant):
             -8.5684619912733797e-04, 7.0123701205311345e-04,
             -5.7236733234294261e-04, 4.6306552021452882e-04,
             -3.6886475367444002e-04, 1.5040954902298390e-04], dtype=float),
-        16: jnp.array([
+        16: np.array([
             8.7223994695383245e-01, 7.6045758887633361e-02,
             -1.7129391549300460e-02, 7.6754541194282476e-03,
             -4.4445780003925933e-03, 2.9515932830727230e-03,
@@ -928,7 +942,7 @@ class Lanczos(Interpolant):
             -5.8604031641364715e-04, 4.8383224833227180e-04,
             -3.9594161181058529e-04, 3.1937075418754133e-04,
             -1.3180105869222726e-04], dtype=float),
-        17: jnp.array([
+        17: np.array([
             8.7228724908408983e-01, 7.5998971448148489e-02,
             -1.7084134836402289e-02, 7.6327045089459814e-03,
             -4.4052470143101669e-03, 2.9165042259113850e-03,
@@ -938,7 +952,7 @@ class Lanczos(Interpolant):
             -5.9276553972714599e-04, 4.9644913927172625e-04,
             -4.1398268512120632e-04, 3.4224428911411873e-04,
             -2.7916255528629238e-04, 1.1644315484903639e-04], dtype=float),
-        18: jnp.array([
+        18: np.array([
             8.7232689100798066e-01, 7.5959712956827338e-02,
             -1.7046017805648218e-02, 7.5964606773141321e-03,
             -4.3715650387017120e-03, 2.8860139700952014e-03,
@@ -949,7 +963,7 @@ class Lanczos(Interpolant):
             -4.2549364826763872e-04, 3.5796893458213912e-04,
             -2.9864805145927314e-04, 2.4606304027479520e-04,
             -1.0362070336560659e-04], dtype=float),
-        19: jnp.array([
+        19: np.array([
             8.7236044158998860e-01, 7.5926452741888195e-02,
             -1.7013622704380147e-02, 7.5654876082696665e-03,
             -4.3425416523476855e-03, 2.8594278657083846e-03,
@@ -960,7 +974,7 @@ class Lanczos(Interpolant):
             -4.3232104020823621e-04, 3.6840727705250476e-04,
             -3.1240629187239864e-04, 2.6279030743023345e-04,
             -2.1849583061638169e-04, 9.2804910540045815e-05], dtype=float),
-        20: jnp.array([
+        20: np.array([
             8.7238908771063439e-01, 7.5898029757744429e-02,
             -1.6985864988803168e-02, 7.5388249542491558e-03,
             -4.3173835651028961e-03, 2.8361560238244453e-03,
@@ -972,7 +986,7 @@ class Lanczos(Interpolant):
             -3.2184401158880078e-04, 2.7487712165928825e-04,
             -2.3295672923797007e-04, 1.9529727563949068e-04,
             -8.3597962681059536e-05], dtype=float),
-        21: jnp.array([
+        21: np.array([
             8.7241374066547217e-01, 7.5873550551340735e-02,
             -1.6961904110473453e-02, 7.5157182853181478e-03,
             -4.2954526665775292e-03, 2.8157027761250950e-03,
@@ -984,7 +998,7 @@ class Lanczos(Interpolant):
             -3.2804320987374932e-04, 2.8340127614368980e-04,
             -2.4361905533554343e-04, 2.0787992034422971e-04,
             -1.7559354356606557e-04, 7.5695943263817707e-05], dtype=float),
-        22: jnp.array([
+        22: np.array([
             8.7243510952874703e-01, 7.5852318603272587e-02,
             -1.6941080818261168e-02, 7.4955691550713617e-03,
             -4.2762329287431644e-03, 2.7976535151004213e-03,
@@ -997,7 +1011,7 @@ class Lanczos(Interpolant):
             -2.5131937483122271e-04, 2.1732403533461197e-04,
             -1.8660717479672992e-04, 1.5871831036838648e-04,
             -6.8863443560681072e-05], dtype=float),
-        23: jnp.array([
+        23: np.array([
             8.7245375270399328e-01, 7.5833784494476197e-02,
             -1.6922872388902346e-02, 7.4778984814789003e-03,
             -4.2593046027017932e-03, 2.7816618095121959e-03,
@@ -1010,7 +1024,7 @@ class Lanczos(Interpolant):
             -2.5672281594250180e-04, 2.2428666875100081e-04,
             -1.9500547130615447e-04, 1.6841157506093199e-04,
             -1.4415643723277331e-04, 6.2915835299457630e-05], dtype=float),
-        24: jnp.array([
+        24: np.array([
             8.7247011477047076e-01, 7.5817510174385608e-02,
             -1.6906860187092181e-02, 7.4623194228004095e-03,
             -4.2443241853712000e-03, 2.7674379023744462e-03,
@@ -1024,7 +1038,7 @@ class Lanczos(Interpolant):
             -2.0131008554716406e-04, 1.7590842016538329e-04,
             -1.5273096884774962e-04, 1.3150467872105143e-04,
             -5.7706672578191118e-05], dtype=float),
-        25: jnp.array([
+        25: np.array([
             8.7248455323036556e-01, 7.5803142951737873e-02,
             -1.6892705839008548e-02, 7.4485170857846545e-03,
             -4.2310088634876777e-03, 2.7547388884928393e-03,
@@ -1038,7 +1052,7 @@ class Lanczos(Interpolant):
             -2.0594683276384606e-04, 1.8162712002948100e-04,
             -1.5944761834648776e-04, 1.3912529030291550e-04,
             -1.2044378908257909e-04, 5.3118594590042846e-05], dtype=float),
-        26: jnp.array([
+        26: np.array([
             8.7249735820063523e-01, 7.5790396300352780e-02,
             -1.6880133511645610e-02, 7.4362331971641049e-03,
             -4.2191244024610613e-03, 2.7433605195079330e-03,
@@ -1053,7 +1067,7 @@ class Lanczos(Interpolant):
             -1.6464483369968912e-04, 1.4516394569028066e-04,
             -1.2724620052677611e-04, 1.1071840388516905e-04,
             -4.9056660028197339e-05], dtype=float),
-        27: jnp.array([
+        27: np.array([
             8.7250876709889491e-01, 7.5779035514417295e-02,
             -1.6868916579437666e-02, 7.4252544156374715e-03,
             -4.2084756787176842e-03, 2.7331304515287470e-03,
@@ -1068,7 +1082,7 @@ class Lanczos(Interpolant):
             -1.6860484863931961e-04, 1.4989680901512291e-04,
             -1.3269333113477609e-04, 1.1681515570485079e-04,
             -1.0212231839813374e-04, 4.5443397789426126e-05], dtype=float),
-        28: jnp.array([
+        28: np.array([
             8.7251897572658565e-01, 7.5768866862828438e-02,
             -1.6858867483315169e-02, 7.4154033396151200e-03,
             -4.1988992421305438e-03, 2.7239027165823207e-03,
@@ -1084,7 +1098,7 @@ class Lanczos(Interpolant):
             -1.3701227971507239e-04, 1.2174420936681089e-04,
             -1.0760733851429796e-04, 9.4487571582612369e-05,
             -4.2215086924736379e-05], dtype=float),
-        29: jnp.array([
+        29: np.array([
             8.7252814672517331e-01, 7.5759729300683573e-02,
             -1.6849829940161199e-02, 7.4065315297353416e-03,
             -4.1902574418264428e-03, 2.7155532080510806e-03,
@@ -1100,7 +1114,7 @@ class Lanczos(Interpolant):
             -1.4039579409560427e-04, 1.2569366589233272e-04,
             -1.1208095148205686e-04, 9.9439732125518435e-05,
             -8.7676252916474282e-05, 3.9318928927118588e-05], dtype=float),
-        30: jnp.array([
+        30: np.array([
             8.7253641609360022e-01, 7.5751488071776771e-02,
             -1.6841672901764325e-02, 7.3985140506990640e-03,
             -4.1824337607948240e-03, 2.7079759953663679e-03,
@@ -1119,58 +1133,58 @@ class Lanczos(Interpolant):
             -3.6710877004442137e-05], dtype=float),
     }
     _unit_integrals_conserve_dc = {
-        1: jnp.array([0.8465162792377735, 0.07670762325450639], dtype=float),
-        2: jnp.array([
+        1: np.array([0.8465162792377735, 0.07670762325450639], dtype=float),
+        2: np.array([
             0.8392495486404705, 0.09164303260613273,
             -0.011263991256750852], dtype=float),
-        3: jnp.array([
+        3: np.array([
             0.8632681168763658, 0.08589201158463194,
             -0.022083030965503198, 0.004555815429348342], dtype=float),
-        4: jnp.array([
+        4: np.array([
             0.8650618038636482, 0.08148195151403913,
             -0.021076170181741696, 0.009466820720409927,
             -0.00240302266580677], dtype=float),
-        5: jnp.array([
+        5: np.array([
             0.8689359970259309, 0.07970029234018064,
             -0.020036683900998796, 0.009568395787771822,
             -0.005189727741783341, 0.0014894780779962505], dtype=float),
-        6: jnp.array([
+        6: np.array([
             0.8694137791076688, 0.07840978854063436,
             -0.0191922989228868, 0.009232601681276926,
             -0.0053818745239808796, 0.0032338189122908144,
             -0.0010087824853216595], dtype=float),
-        7: jnp.array([
+        7: np.array([
             8.7068121586962599e-01, 7.7760175859505912e-02,
             -1.8640769800640181e-02, 8.9012045828225275e-03,
             -5.3128961484314877e-03, 3.4223758240124881e-03,
             -2.2002576627743846e-03, 7.2946945446464068e-04], dtype=float),
-        8: jnp.array([
+        8: np.array([
             8.7087122663453687e-01, 7.7232562835075971e-02,
             -1.8226713770444866e-02, 8.6102310410169185e-03,
             -5.1670476898779145e-03, 3.4289010057657597e-03,
             -2.3489300172765616e-03, 1.5865771790561077e-03,
             -5.5113365980760675e-04], dtype=float),
-        9: jnp.array([
+        9: np.array([
             8.7143493458904431e-01, 7.6932265134858360e-02,
             -1.7942639888338646e-02, 8.3865827097040022e-03,
             -5.0232309792990620e-03, 3.3746385423195635e-03,
             -2.3849785913625278e-03, 1.7051927318036352e-03,
             -1.1967036642138026e-03, 4.3136438901798563e-04], dtype=float),
-        10: jnp.array([
+        10: np.array([
             8.7152875015003661e-01, 7.6668658898206218e-02,
             -1.7720836410665596e-02, 8.2053052134872188e-03,
             -4.8915130064100063e-03, 3.2991092084359097e-03,
             -2.3683360136017872e-03, 1.7458513443762314e-03,
             -1.2889544498105386e-03, 9.3291676738900878e-04,
             -3.4654578014316011e-04], dtype=float),
-        11: jnp.array([
+        11: np.array([
             8.7182701261013895e-01, 7.6506845944911556e-02,
             -1.7560280273053473e-02, 8.0658090349930087e-03,
             -4.7816169415337648e-03, 3.2244386963457415e-03,
             -2.3320505873390125e-03, 1.7486438928736800e-03,
             -1.3291042400695723e-03, 1.0064740823627395e-03,
             -7.4730059331932163e-04, 2.8461150002295668e-04], dtype=float),
-        12: jnp.array([
+        12: np.array([
             8.7187999180800302e-01, 7.6357063833305372e-02,
             -1.7429812583281152e-02, 7.9517835187695729e-03,
             -4.6878090801196039e-03, 3.1543389326472498e-03,
@@ -1178,7 +1192,7 @@ class Lanczos(Interpolant):
             -1.3395135178857025e-03, 1.0423877224169636e-03,
             -8.0591440128258737e-04, 6.1143271851679844e-04,
             -2.3782098971811296e-04], dtype=float),
-        13: jnp.array([
+        13: np.array([
             8.7205651245197036e-01, 7.6260329598980603e-02,
             -1.7331346297259138e-02, 7.8619442533867916e-03,
             -4.6107275866607853e-03, 3.0929673491064623e-03,
@@ -1186,7 +1200,7 @@ class Lanczos(Interpolant):
             -1.3345286416164889e-03, 1.0564549386888288e-03,
             -8.3778481703841387e-04, 6.5912362112473504e-04,
             -5.0940816568803755e-04, 2.0173889416053422e-04], dtype=float),
-        14: jnp.array([
+        14: np.array([
             8.7208929429187798e-01, 7.6167314173495135e-02,
             -1.7248704480452334e-02, 7.7870379659251690e-03,
             -4.5452451604283050e-03, 3.0387135114274592e-03,
@@ -1195,7 +1209,7 @@ class Lanczos(Interpolant):
             -8.5250761240626010e-04, 6.8669310792062658e-04,
             -5.4838586727713799e-04, 4.3069822413788851e-04,
             -1.7324684641373308e-04], dtype=float),
-        15: jnp.array([
+        15: np.array([
             8.7220228086915630e-01, 7.6105015315345276e-02,
             -1.7184310432719251e-02, 7.7266027585287623e-03,
             -4.4909646081825226e-03, 2.9921931283320119e-03,
@@ -1204,7 +1218,7 @@ class Lanczos(Interpolant):
             -8.5687809046123338e-04, 7.0126311118012027e-04,
             -5.7238863486558128e-04, 4.6308275463621986e-04,
             -3.6887848215115331e-04, 1.5041516736960623e-04], dtype=float),
-        16: jnp.array([
+        16: np.array([
             8.7222395364765015e-01, 7.6043379470208547e-02,
             -1.7128863829277020e-02, 7.6752182700120285e-03,
             -4.4444415499702789e-03, 2.9515027045387025e-03,
@@ -1214,7 +1228,7 @@ class Lanczos(Interpolant):
             -5.8602234170264432e-04, 4.8381740861131231e-04,
             -3.9592946783596728e-04, 3.1936095870500593e-04,
             -1.3179700236266062e-04], dtype=float),
-        17: jnp.array([
+        17: np.array([
             8.7230058718898085e-01, 7.6000954485776234e-02,
             -1.7084573752855357e-02, 7.6329000941166500e-03,
             -4.4053597965662749e-03, 2.9165788633803381e-03,
@@ -1224,7 +1238,7 @@ class Lanczos(Interpolant):
             -5.9278070108256223e-04, 4.9646183697964912e-04,
             -4.1399327351884985e-04, 3.4225304265024032e-04,
             -2.7916969540569040e-04, 1.1644614272353818e-04], dtype=float),
-        18: jnp.array([
+        18: np.array([
             8.7231565258007016e-01, 7.5958043070210701e-02,
             -1.7045648834524654e-02, 7.5962966753538221e-03,
             -4.3714707439979471e-03, 2.8859517440674581e-03,
@@ -1235,7 +1249,7 @@ class Lanczos(Interpolant):
             -4.2548447940956257e-04, 3.5796122082968956e-04,
             -2.9864161599898439e-04, 2.4605773793840048e-04,
             -1.0361846365053765e-04], dtype=float),
-        19: jnp.array([
+        19: np.array([
             8.7236999951964245e-01, 7.5927872240629551e-02,
             -1.7013935891760718e-02, 7.5656265115178452e-03,
             -4.3426213107755395e-03, 2.8594802969067116e-03,
@@ -1246,7 +1260,7 @@ class Lanczos(Interpolant):
             -4.3232896269473626e-04, 3.6841402825014334e-04,
             -3.1241201681421422e-04, 2.6279512314145257e-04,
             -2.1849983462646975e-04, 9.2806616155833853e-05], dtype=float),
-        20: jnp.array([
+        20: np.array([
             8.7238089185504586e-01, 7.5896813066217039e-02,
             -1.6985596884775269e-02, 7.5387062716141470e-03,
             -4.3173156578507734e-03, 2.8361114327190564e-03,
@@ -1258,7 +1272,7 @@ class Lanczos(Interpolant):
             -3.2183895450690501e-04, 2.7487280256993391e-04,
             -2.3295306883591545e-04, 1.9529420696674002e-04,
             -8.3596645493438584e-05], dtype=float),
-        21: jnp.array([
+        21: np.array([
             8.7242082177323477e-01, 7.5874601381641801e-02,
             -1.6962135414044184e-02, 7.5158205076777986e-03,
             -4.2955110374426845e-03, 2.8157410230346064e-03,
@@ -1270,7 +1284,7 @@ class Lanczos(Interpolant):
             -3.2804766308928859e-04, 2.8340512332804767e-04,
             -2.4362236246924825e-04, 2.0788274231868027e-04,
             -1.7559592725666228e-04, 7.5696973546588643e-05], dtype=float),
-        22: jnp.array([
+        22: np.array([
             8.7242895016736588e-01, 7.5851404850236531e-02,
             -1.6940879878094558e-02, 7.4954804807582463e-03,
             -4.2761823851407499e-03, 2.7976204613368570e-03,
@@ -1283,7 +1297,7 @@ class Lanczos(Interpolant):
             -2.5131640740119093e-04, 2.1732146930435599e-04,
             -1.8660497145197701e-04, 1.5871643631526562e-04,
             -6.8862628413863947e-05], dtype=float),
-        23: jnp.array([
+        23: np.array([
             8.7245914379788081e-01, 7.5834584057672294e-02,
             -1.6923048071897602e-02, 7.4779759103049716e-03,
             -4.2593486656233017e-03, 2.7816905742820146e-03,
@@ -1296,7 +1310,7 @@ class Lanczos(Interpolant):
             -2.5672546899496528e-04, 2.2428898659365308e-04,
             -1.9500748654685722e-04, 1.6841331547353097e-04,
             -1.4415792698833072e-04, 6.2916487058676165e-05], dtype=float),
-        24: jnp.array([
+        24: np.array([
             8.7246536950028220e-01, 7.5816806566238668e-02,
             -1.6906705700787391e-02, 7.4622514135075655e-03,
             -4.2442855384994460e-03, 2.7674127136869966e-03,
@@ -1310,7 +1324,7 @@ class Lanczos(Interpolant):
             -2.0130825443927662e-04, 1.7590682011087909e-04,
             -1.5272957961364562e-04, 1.3150348255857268e-04,
             -5.7706146465297619e-05], dtype=float),
-        25: jnp.array([
+        25: np.array([
             8.7248875196659104e-01, 7.5803765391887615e-02,
             -1.6892842415272138e-02, 7.4485771496326375e-03,
             -4.2310429512542420e-03, 2.7547610733581005e-03,
@@ -1324,7 +1338,7 @@ class Lanczos(Interpolant):
             -2.0594849025015860e-04, 1.8162858178584428e-04,
             -1.5944890159912006e-04, 1.3912640999964577e-04,
             -1.2044475842971024e-04, 5.3119023046254830e-05], dtype=float),
-        26: jnp.array([
+        26: np.array([
             8.7249362530848429e-01, 7.5789843024876430e-02,
             -1.6880012181469790e-02, 7.4361798866050205e-03,
             -4.2190941825087317e-03, 2.7433408779477366e-03,
@@ -1339,7 +1353,7 @@ class Lanczos(Interpolant):
             -1.6464365566885251e-04, 1.4516290704510429e-04,
             -1.2724529008227488e-04, 1.1071761169578391e-04,
             -4.9056308276636971e-05], dtype=float),
-        27: jnp.array([
+        27: np.array([
             8.7251210066417650e-01, 7.5779529521346076e-02,
             -1.6869024856588942e-02, 7.4253019522472295e-03,
             -4.2085025973400683e-03, 2.7331479262374778e-03,
@@ -1354,7 +1368,7 @@ class Lanczos(Interpolant):
             -1.6860592593073375e-04, 1.4989776677182335e-04,
             -1.3269417897076742e-04, 1.1681590208857079e-04,
             -1.0212297090357753e-04, 4.5443688746986498e-05], dtype=float),
-        28: jnp.array([
+        28: np.array([
             8.7251598657722484e-01, 7.5768423963066975e-02,
             -1.6858770452699619e-02, 7.4153607717001024e-03,
             -4.1988751600420919e-03, 2.7238871005104146e-03,
@@ -1370,7 +1384,7 @@ class Lanczos(Interpolant):
             -1.3701149474891369e-04, 1.2174351187400578e-04,
             -1.0760672201367076e-04, 9.4487030246761034e-05,
             -4.2214844585348015e-05], dtype=float),
-        29: jnp.array([
+        29: np.array([
             8.7253083736575510e-01, 7.5760127917557707e-02,
             -1.6849917232974677e-02, 7.4065698003132514e-03,
             -4.1902790740866039e-03, 2.7155672213687097e-03,
@@ -1386,7 +1400,7 @@ class Lanczos(Interpolant):
             -1.4039651810862980e-04, 1.2569431408703590e-04,
             -1.1208152947681375e-04, 9.9440244930514059e-05,
             -8.7676705058335925e-05, 3.9319132083084142e-05], dtype=float),
-        30: jnp.array([
+        30: np.array([
             8.7253398555054584e-01, 7.5751128032722340e-02,
             -1.6841594086663234e-02, 7.3984795175748392e-03,
             -4.1824142564461488e-03, 2.7079633721913449e-03,
@@ -1421,24 +1435,18 @@ class Lanczos(Interpolant):
         self._n = n
         self._conserve_dc = conserve_dc
         self._gsparams = GSParams.check(gsparams)
-
-    @property
-    def _C_arr(self):
-        return self._C_arr_vals[self._n]
-
-    @property
-    def _K_arr(self):
-        return self._K_arr_vals[self._n]
+        self._C_arr = self._C_arr_vals[n]
+        self._K_arr = self._K_arr_vals[n]
 
     @property
     def _du(self):
         return (
             self._gsparams.table_spacing
-            * jnp.power(self._gsparams.kvalue_accuracy / 200.0, 0.25)
+            * np.power(self._gsparams.kvalue_accuracy / 200.0, 0.25)
             / self._n
         )
 
-    @property
+    @lazy_property
     def _umax(self):
         return _find_umax_lanczos(
             self._du,
@@ -1482,7 +1490,7 @@ class Lanczos(Interpolant):
 
     # this is a pure function and we apply JIT ahead of time since this
     # one is pretty slow
-    @jax.jit
+    @functools.partial(jax.jit, static_argnames=("conserve_dc", "n", "_K"))
     def _xval(x, n, conserve_dc, _K):
         x = jnp.abs(x)
 
@@ -1558,6 +1566,7 @@ class Lanczos(Interpolant):
     def _xval_noraise(self, x):
         return Lanczos._xval(x, self._n, self._conserve_dc, self._K_arr)
 
+    @functools.partial(jax.jit, static_argnames=("n",))
     def _raw_uval(u, n):
         # this function is used in the init and so was causing a recursion depth error
         # when jitted, so I made it a pure function - MRB
@@ -1576,7 +1585,7 @@ class Lanczos(Interpolant):
 
     # this is a pure function and we apply JIT ahead of time since this
     # one is pretty slow
-    @jax.jit
+    @functools.partial(jax.jit, static_argnames=("n", "conserve_dc", "_C"))
     def _uval(u, n, conserve_dc, _C):
         retval = Lanczos._raw_uval(u, n)
 
@@ -1676,48 +1685,65 @@ class Lanczos(Interpolant):
             return self._unit_integrals_no_conserve_dc[self._n][:n]
 
 
-# we apply JIT here to esnure the class init is fast
-@jax.jit
+@np.vectorize(excluded={1})
+def _gs_raw_uval(u, n):
+    # from galsim
+    # // F(u) = ( (vp+1) Si((vp+1)pi) - (vp-1) Si((vp-1)pi) +
+    # //          (vm-1) Si((vm-1)pi) - (vm+1) Si((vm+1)pi) ) / 2pi
+    vp = n * (2.0 * u + 1.0)
+    vm = n * (2.0 * u - 1.0)
+    vpp1 = vp + 1.0
+    vpm1 = vp - 1.0
+    vmp1 = vm + 1.0
+    vmm1 = vm - 1.0
+    retval = (
+        vmm1 * _galsim.bessel.si(np.pi * vmm1)
+        - vmp1 * _galsim.bessel.si(np.pi * vmp1)
+        - vpm1 * _galsim.bessel.si(np.pi * vpm1)
+        + vpp1 * _galsim.bessel.si(np.pi * vpp1)
+    )
+    return retval / (2.0 * np.pi)
+
+
+@np.vectorize(excluded={1, 2})
+def _gs_uval(u, n, conserve_dc):
+    _C = Lanczos._C_arr_vals[n]
+    retval = _gs_raw_uval(u, n)
+
+    if conserve_dc:
+        retval *= _C[0]
+        retval += _C[1] * (_gs_raw_uval(u + 1.0, n) + _gs_raw_uval(u - 1.0, n))
+        retval += _C[2] * (_gs_raw_uval(u + 2.0, n) + _gs_raw_uval(u - 2.0, n))
+        retval += _C[3] * (_gs_raw_uval(u + 3.0, n) + _gs_raw_uval(u - 3.0, n))
+        retval += _C[4] * (_gs_raw_uval(u + 4.0, n) + _gs_raw_uval(u - 4.0, n))
+        retval += _C[5] * (_gs_raw_uval(u + 5.0, n) + _gs_raw_uval(u - 5.0, n))
+
+    return retval
+
+
+@functools.lru_cache(maxsize=128)
 def _find_umax_lanczos(_du, n, conserve_dc, _C, kva):
-    def _cond(vals):
-        umax, u = vals
-        return (u - umax < 1.0 / n) | (u < 1.1)
-
-    def _body(vals):
-        umax, u = vals
-        uval = Lanczos._uval(u, n, conserve_dc, _C)
-        umax = jax.lax.cond(
-            jnp.abs(uval) > kva,
-            lambda umax, u: u,
-            lambda umax, u: umax,
-            umax,
-            u,
-        )
-        return [umax, u + _du]
-
-    return jax.lax.while_loop(
-        _cond,
-        _body,
-        [0.0, 0.0],
-    )[0]
+    u = 0.0
+    umax = -np.inf
+    while (u - umax < 1.0 / n) or (u < 1.1):
+        uval = _gs_uval(u, n, conserve_dc)
+        if np.abs(uval) > kva:
+            umax = u
+        u += _du
+    return umax
 
 
-@jax.jit
 def _compute_C_K_lanczos(n):
-    _K = jnp.concatenate(
-        (jnp.zeros(1), Lanczos._raw_uval(jnp.arange(5) + 1.0, n)), axis=0
+    _K = np.concatenate((np.zeros(1), _gs_raw_uval(np.arange(5) + 1.0, n)), axis=0)
+    _C = np.zeros(6)
+    _C[0] = 1.0 + 2.0 * (
+        _K[1] * (1.0 + 3.0 * _K[1] + _K[2] + _K[3]) + _K[2] + _K[3] + _K[4] + _K[5]
     )
-    _C = jnp.zeros(6)
-    _C = _C.at[0].set(
-        1.0
-        + 2.0
-        * (_K[1] * (1.0 + 3.0 * _K[1] + _K[2] + _K[3]) + _K[2] + _K[3] + _K[4] + _K[5])
-    )
-    _C = _C.at[1].set(-_K[1] * (1.0 + 4.0 * _K[1] + _K[2] + 2.0 * _K[3]))
-    _C = _C.at[2].set(_K[1] * (_K[1] - 2.0 * _K[2] + _K[3]) - _K[2])
-    _C = _C.at[3].set(_K[1] * (_K[1] - 2.0 * _K[3]) - _K[3])
-    _C = _C.at[4].set(_K[1] * _K[3] - _K[4])
-    _C = _C.at[5].set(-_K[5])
+    _C[1] = -_K[1] * (1.0 + 4.0 * _K[1] + _K[2] + 2.0 * _K[3])
+    _C[2] = _K[1] * (_K[1] - 2.0 * _K[2] + _K[3]) - _K[2]
+    _C[3] = _K[1] * (_K[1] - 2.0 * _K[3]) - _K[3]
+    _C[4] = _K[1] * _K[3] - _K[4]
+    _C[5] = -_K[5]
 
     return _C, _K
 
@@ -1725,5 +1751,4 @@ def _compute_C_K_lanczos(n):
 Lanczos._C_arr_vals = {}
 Lanczos._K_arr_vals = {}
 for n in range(1, 31):
-    Lanczos._C_arr_vals[n] = _compute_C_K_lanczos(n)[0]
-    Lanczos._K_arr_vals[n] = _compute_C_K_lanczos(n)[1]
+    Lanczos._C_arr_vals[n], Lanczos._K_arr_vals[n] = _compute_C_K_lanczos(n)


### PR DESCRIPTION
This PR is a small refactor to move the init of the interpolant classes to the host. This pattern makes more sense in general since once we apply JIT, the constants computed on the host will get embeded into the JAX code and moved to the device with the code. 