### PR TITLE
feat: add benchmark for RNG discard operation

### DIFF
--- a/tests/jax/test_benchmarks.py
+++ b/tests/jax/test_benchmarks.py
@@ -242,12 +242,14 @@ def test_benchmark_gaussian_init(benchmark, kind):
 
 @jax.jit
 def _run_benchmark_rng_discard(rng):
-    return rng.discard(1000)
+    rng.discard(1000)
+    return rng._state.key
 
 
-def test_benchmark_rng_discard(benchmark):
+@pytest.mark.parametrize("kind", ["compile", "run"])
+def test_benchmark_rng_discard(benchmark, kind):
     rng = jgs.BaseDeviate(seed=42)
     dt = _run_benchmarks(
-        benchmark, "run", lambda: _run_benchmark_rng_discard(rng).block_until_ready()
+        benchmark, kind, lambda: _run_benchmark_rng_discard(rng).block_until_ready()
     )
     print(f"time: {dt:0.4g} ms", end=" ")

--- a/tests/jax/test_benchmarks.py
+++ b/tests/jax/test_benchmarks.py
@@ -238,3 +238,16 @@ def test_benchmark_gaussian_init(benchmark, kind):
         benchmark, kind, lambda: _run_gaussian_bench_init().block_until_ready()
     )
     print(f"time: {dt:0.4g} ms", end=" ")
+
+
+@jax.jit
+def _run_benchmark_rng_discard(rng):
+    return rng.discard(1000)
+
+
+def test_benchmark_rng_discard(benchmark):
+    rng = jgs.BaseDeviate(seed=42)
+    dt = _run_benchmarks(
+        benchmark, "run", lambda: _run_benchmark_rng_discard(rng).block_until_ready()
+    )
+    print(f"time: {dt:0.4g} ms", end=" ")


### PR DESCRIPTION
This PR adds a benchmark for the discard operation so that we can test the effect of removing the `fori_loop` in another PR.