### PR TITLE
feat: use None as default for trunc to avoid JAX branches on trunc value

### DIFF
--- a/tests/jax/test_moffat_comp_galsim.py
+++ b/tests/jax/test_moffat_comp_galsim.py
@@ -35,7 +35,7 @@ def test_moffat_comp_galsim_maxk():
                 beta=psf.beta,
                 scale_radius=psf.scale_radius,
                 flux=psf.flux,
-                trunc=psf.trunc,
+                trunc=psf.trunc or 0.0,
             )
             gpsf = gpsf.withGSParams(maxk_threshold=thresh)
             fk = psf.kValue(psf.maxk, 0).real / psf.flux

--- a/tests/jax/test_moffat_comp_galsim.py
+++ b/tests/jax/test_moffat_comp_galsim.py
@@ -41,7 +41,7 @@ def test_moffat_comp_galsim_maxk():
             fk = psf.kValue(psf.maxk, 0).real / psf.flux
 
             print(
-                f"{psf.beta} \t {int(psf.trunc)} \t {thresh:.1e} \t {fk:.3e} \t {psf.maxk:.3e} \t {gpsf.maxk:.3e}"
+                f"{psf.beta} \t {int(psf.trunc or 0.0)} \t {thresh:.1e} \t {fk:.3e} \t {psf.maxk:.3e} \t {gpsf.maxk:.3e}"
             )
             np.testing.assert_allclose(
                 psf.kValue(0.0, 0.0), gpsf.kValue(0.0, 0.0), rtol=1e-5

--- a/tests/jax/test_vmapping.py
+++ b/tests/jax/test_vmapping.py
@@ -7,7 +7,7 @@ e = jnp.ones(2)
 
 
 def duplicate(params):
-    return {x: y * e for x, y in params.items()}
+    return {x: y * e if y is not None else [None] * 2 for x, y in params.items()}
 
 
 def test_gaussian_vmapping():


### PR DESCRIPTION
This should help the code avoid any backpropagation through unused code for trunc > 0.