### PR TITLE
feat: do not support trunc or high maxk thresholds for Moffat profiles

### DIFF
--- a/jax_galsim/moffat.py
+++ b/jax_galsim/moffat.py
@@ -57,11 +57,6 @@ class Moffat(GSObject):
         if has_tracers(trunc) or np.any(trunc != 0):
             raise ValueError("JAX-GalSim does not support truncated Moffat profiles!")
 
-        if self.gsparams.maxk_threshold > 0.1:
-            raise ValueError(
-                "JAX-GalSim Moffat profiles do not support gsparams.maxk_threshold values greater than 0.1!"
-            )
-
         # Parse the radius options
         if half_light_radius is not None:
             if scale_radius is not None or fwhm is not None:
@@ -112,6 +107,11 @@ class Moffat(GSObject):
                 trunc=trunc,
                 flux=flux,
                 gsparams=gsparams,
+            )
+
+        if self.gsparams.maxk_threshold > 0.1:
+            raise ValueError(
+                "JAX-GalSim Moffat profiles do not support gsparams.maxk_threshold values greater than 0.1!"
             )
 
     @property

--- a/tests/galsim_tests_config.yaml
+++ b/tests/galsim_tests_config.yaml
@@ -145,3 +145,4 @@ allowed_failures:
   - "module 'jax_galsim' has no attribute 'LookupTable2D'"
   - "module 'jax_galsim' has no attribute 'zernike'"
   - "Invalid TFORM4: 1PE(7)"  # see https://github.com/astropy/astropy/issues/15477
+  - "JAX-GalSim does not support truncated Moffat profiles!"

--- a/tests/jax/test_moffat_comp_galsim.py
+++ b/tests/jax/test_moffat_comp_galsim.py
@@ -22,9 +22,6 @@ def test_moffat_comp_galsim_maxk():
         galsim.Moffat(beta=1.22, scale_radius=23, flux=23),
         galsim.Moffat(beta=3.6, scale_radius=2, flux=23),
         galsim.Moffat(beta=12.9, scale_radius=5, flux=23),
-        galsim.Moffat(beta=1.22, scale_radius=7, flux=23, trunc=30),
-        galsim.Moffat(beta=3.6, scale_radius=9, flux=23, trunc=50),
-        galsim.Moffat(beta=12.9, scale_radius=11, flux=23, trunc=1000),
     ]
     threshs = [1.0e-3, 1.0e-4, 0.03]
     print("\nbeta \t trunc \t thresh \t kValue(maxk) \t jgs-maxk \t gs-maxk")


### PR DESCRIPTION
This PR removes support in Moffat profiles for

- truncation (only needed for beta < 1.1)
- high maxk_thresholds

These changes will allow us to make the code much more efficient through the use of splines and Pade approximations.