### PR TITLE
fix: better accuracy lanczos fourier-space interp

### DIFF
--- a/jax_galsim/interpolant.py
+++ b/jax_galsim/interpolant.py
@@ -1501,8 +1501,10 @@ class Lanczos(Interpolant):
         with jax.ensure_compile_time_eval():
             _idata = _lanczos_kval_interp_table(
                 n,
-                du / 3.0,  # jax-galsim uses a slightly less accurate interpolation
+                # jax-galsim uses a slightly less accurate interpolation
                 # function (akima vs cubic spline) and so needs a smaller spacing
+                # 2.3x appears to be ok
+                du / 2.3,
                 krange,
                 conserve_dc,
             )

--- a/jax_galsim/interpolant.py
+++ b/jax_galsim/interpolant.py
@@ -1498,12 +1498,14 @@ class Lanczos(Interpolant):
     # it gets recompiled as needed for combinations of n, conserve_dc, du, and krange
     @functools.partial(jax.jit, static_argnames=("n", "conserve_dc", "du", "krange"))
     def _interp_kval(k, n, conserve_dc, du, krange):
-        _idata = _lanczos_kval_interp_table(
-            n,
-            du,
-            krange,
-            conserve_dc,
-        )
+        with jax.ensure_compile_time_eval():
+            _idata = _lanczos_kval_interp_table(
+                n,
+                du / 3.0,  # jax-galsim uses a slightly less accurate interpolation
+                # function (akima vs cubic spline) and so needs a smaller spacing
+                krange,
+                conserve_dc,
+            )
         return akima_interp(jnp.abs(k), *_idata, fixed_spacing=True)
 
     def _kval_noraise(self, k):


### PR DESCRIPTION
jax-galsim uses a lower-accuracy akima interpolant instead of a cubic spline when interpolating the k-space table for the fourier transform of the Lanczos interpolant. This causes a loss in accuracy. For jax-galsim, I am increasing the number of points being interpolated by 2.3x. The cost of computing the table comes at compile time, and it is cached on the CPU side, so we should not see big performance losses in most cases.

xref: https://github.com/GalSim-developers/GalSim-for-JAX-GalSim-Testing/pull/9