### PR TITLE
doc: include conda install command in installation guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx.ext.viewcode",  # "View source" links
     "sphinx.ext.intersphinx",  # cross-links to external docs
     "sphinx_design",  # dropdown / collapsible directives
+    "sphinx_copybutton",  # copy button for code blocks
 ]
 
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,10 @@ Quick Install
 
    pip install jax-galsim
 
+.. code-block:: bash
+
+   conda install -c conda-forge jax-galsim
+
 See :doc:`installation` for GPU support and development setup.
 
 Minimal Example

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,6 +8,10 @@ Quick Install
 
    pip install jax-galsim
 
+.. code-block:: bash
+
+   conda install -c conda-forge jax-galsim
+
 This installs JAX-GalSim and its dependencies (JAX, NumPy, GalSim, Astropy).
 
 GPU Support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies    = ["numpy >=1.18.0", "galsim >=2.7.0", "jax >=0.6.0", "astropy >
 
 [project.optional-dependencies]
 dev  = ["pytest", "pytest-codspeed"]
-docs = ["sphinx>=7.0", "furo>=2024.1.29", "sphinx-design>=0.5"]
+docs = ["sphinx>=7.0", "furo>=2024.1.29", "sphinx-design>=0.5", "sphinx-copybutton"]
 
 [project.urls]
 home = "https://github.com/GalSim-developers/JAX-GalSim"


### PR DESCRIPTION
Added conda installation instructions for jax-galsim.